### PR TITLE
[feat] #10 꽃 아이템 가져오기 기능 추가

### DIFF
--- a/src/main/java/com/fling/fllingbe/domain/item/api/FlowerItemController.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/api/FlowerItemController.java
@@ -1,0 +1,23 @@
+package com.fling.fllingbe.domain.item.api;
+
+import com.fling.fllingbe.domain.item.application.FlowerItemService;
+import com.fling.fllingbe.domain.item.dto.FlowerItemResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+public class FlowerItemController {
+    private final FlowerItemService flowerItemService;
+    @GetMapping(value = "/flower-item")
+    public ResponseEntity<List<FlowerItemResponse>> getFlowerItem(@PathVariable UUID id) {
+        List<FlowerItemResponse> flowerItems = flowerItemService.getFlowerItem(id);
+        return ResponseEntity.ok().body(flowerItems);
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/application/FlowerItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/FlowerItemService.java
@@ -1,0 +1,31 @@
+package com.fling.fllingbe.domain.item.application;
+
+import com.fling.fllingbe.domain.item.domain.FlowerItem;
+import com.fling.fllingbe.domain.item.dto.FlowerItemResponse;
+import com.fling.fllingbe.domain.item.repository.FlowerItemRepository;
+import com.fling.fllingbe.domain.item.repository.FlowerTypeRepository;
+import com.fling.fllingbe.domain.user.domain.User;
+import com.fling.fllingbe.domain.user.exception.UserNotFoundException;
+import com.fling.fllingbe.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FlowerItemService {
+    private final FlowerItemRepository flowerItemRepository;
+    private final UserRepository userRepository;
+    public List<FlowerItemResponse> getFlowerItem(UUID userId) {
+        User user = userRepository.findByUserId(userId).orElseThrow(()->new UserNotFoundException());
+        List<FlowerItem> flowerItems = flowerItemRepository.findByUser(user);
+
+        return  flowerItems.stream()
+                .map(FlowerItemResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerItem.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerItem.java
@@ -15,7 +15,7 @@ import lombok.*;
 public class FlowerItem {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "flower_itme_id")
+    @Column(name = "flower_item_id")
     private Long flowerItemId;
 
     @ManyToOne

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerItem.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerItem.java
@@ -5,13 +5,13 @@ import com.fling.fllingbe.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
 
-@Setter
+
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name = "\"FlowerItem\"")
+@Table
 public class FlowerItem {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerItem.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerItem.java
@@ -1,0 +1,31 @@
+package com.fling.fllingbe.domain.item.domain;
+
+
+import com.fling.fllingbe.domain.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "\"FlowerItem\"")
+public class FlowerItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "flower_itme_id")
+    private Long flowerItemId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToOne
+    @JoinColumn(name = "flower_type_id")
+    private FlowerType flowerType;
+
+    @Column
+    private Long count;
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerType.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerType.java
@@ -1,0 +1,24 @@
+package com.fling.fllingbe.domain.item.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "\"FlowerType\"")
+public class FlowerType {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "flower_type_id")
+    private Long flowerTypeId;
+
+    @Column(name = "flower_name")
+    private String flowerName;
+
+    @Column(name = "price")
+    private Long price;
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerType.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerType.java
@@ -3,7 +3,7 @@ package com.fling.fllingbe.domain.item.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
-@Setter
+
 @Getter
 @Builder
 @NoArgsConstructor

--- a/src/main/java/com/fling/fllingbe/domain/item/dto/FlowerItemResponse.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/dto/FlowerItemResponse.java
@@ -1,0 +1,19 @@
+package com.fling.fllingbe.domain.item.dto;
+
+import com.fling.fllingbe.domain.item.domain.FlowerItem;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FlowerItemResponse {
+    private String flowerType;
+    private Long count;
+
+    public static FlowerItemResponse fromEntity(FlowerItem flowerItem) {
+        return new FlowerItemResponse(flowerItem.getFlowerType().getFlowerName(), flowerItem.getCount());
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/presentation/FlowerItemController.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/presentation/FlowerItemController.java
@@ -1,4 +1,4 @@
-package com.fling.fllingbe.domain.item.api;
+package com.fling.fllingbe.domain.item.presentation;
 
 import com.fling.fllingbe.domain.item.application.FlowerItemService;
 import com.fling.fllingbe.domain.item.dto.FlowerItemResponse;

--- a/src/main/java/com/fling/fllingbe/domain/item/repository/FlowerItemRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/repository/FlowerItemRepository.java
@@ -1,11 +1,13 @@
 package com.fling.fllingbe.domain.item.repository;
 
 import com.fling.fllingbe.domain.item.domain.FlowerItem;
+import com.fling.fllingbe.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FlowerItemRepository extends JpaRepository<FlowerItem, Long> {
     Optional<FlowerItem> findById(Long flowerItemId);
-    Optional<FlowerItem> findByUserId(Long userId);
+    List<FlowerItem> findByUser(User user);
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/repository/FlowerItemRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/repository/FlowerItemRepository.java
@@ -1,0 +1,11 @@
+package com.fling.fllingbe.domain.item.repository;
+
+import com.fling.fllingbe.domain.item.domain.FlowerItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FlowerItemRepository extends JpaRepository<FlowerItem, Long> {
+    Optional<FlowerItem> findById(Long flowerItemId);
+    Optional<FlowerItem> findByUserId(Long userId);
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/repository/FlowerTypeRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/repository/FlowerTypeRepository.java
@@ -1,0 +1,10 @@
+package com.fling.fllingbe.domain.item.repository;
+
+import com.fling.fllingbe.domain.item.domain.FlowerType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FlowerTypeRepository extends JpaRepository<FlowerType, Long> {
+    Optional<FlowerType> findById(Long flowerTypeId);
+}

--- a/src/main/java/com/fling/fllingbe/domain/user/domain/User.java
+++ b/src/main/java/com/fling/fllingbe/domain/user/domain/User.java
@@ -1,0 +1,47 @@
+package com.fling.fllingbe.domain.user.domain;
+
+import com.fling.fllingbe.global.shared.domain.BaseTimeEntity;
+import jakarta.annotation.PreDestroy;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.LocalDateTime;
+
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "\"User\"")
+public class User extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Email
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "nickname")
+    private String nickname;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at")
+    @UpdateTimestamp
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @Column()
+    private LocalDateTime deletedAt;
+
+    @PreDestroy()
+    public void preDestroy() {
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/user/domain/User.java
+++ b/src/main/java/com/fling/fllingbe/domain/user/domain/User.java
@@ -8,6 +8,7 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Setter
 @Getter
@@ -20,7 +21,7 @@ public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "user_id")
-    private Long userId;
+    private UUID userId;
 
     @Email
     @Column(name = "email", nullable = false)

--- a/src/main/java/com/fling/fllingbe/domain/user/domain/User.java
+++ b/src/main/java/com/fling/fllingbe/domain/user/domain/User.java
@@ -30,12 +30,11 @@ public class User extends BaseTimeEntity {
     @Column(name = "nickname")
     private String nickname;
 
-    @CreationTimestamp
+
     @Column(name = "created_at")
     private LocalDateTime createdAt = LocalDateTime.now();
 
     @Column(name = "updated_at")
-    @UpdateTimestamp
     private LocalDateTime updatedAt = LocalDateTime.now();
 
     @Column()

--- a/src/main/java/com/fling/fllingbe/domain/user/domain/User.java
+++ b/src/main/java/com/fling/fllingbe/domain/user/domain/User.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @Table(name = "\"User\"")
 public class User extends BaseTimeEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "user_id")
     private Long userId;
 

--- a/src/main/java/com/fling/fllingbe/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/fling/fllingbe/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package com.fling.fllingbe.domain.user.exception;
+
+import com.fling.fllingbe.global.error.ErrorCode;
+import com.fling.fllingbe.global.error.exception.ServiceException;
+
+public class UserNotFoundException extends ServiceException {
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.fling.fllingbe.domain.user.repository;
+
+import com.fling.fllingbe.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User,UUID> {
+    Optional<User> findByUserId(UUID userId);
+}

--- a/src/main/java/com/fling/fllingbe/global/error/ErrorCode.java
+++ b/src/main/java/com/fling/fllingbe/global/error/ErrorCode.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 public enum ErrorCode {
     INTERNAL_SERVER_ERROR(500, "INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다."),
     INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
-    EXPIRED_TOKEN(403, "EXPIRED_TOKEN", "만료된 토큰입니다.");
-
+    EXPIRED_TOKEN(403, "EXPIRED_TOKEN", "만료된 토큰입니다."),
+    USER_NOT_FOUND(404,"USER_NOT_FOUND","유저를 찾을 수 없습니다.");
     private final int httpStatus;
     private final String code;
     private final String message;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

<br>

유저가 보유하고 있는 꽃 아이템을 모두 가져오는 기능을 추가하였습니다.

## 2. 어떤 위험이나 장애를 발견했나요?

현재 토큰 및 유저를 구분하는 기능이 구현되어있지 않아 임시적으로 pathvariable을 사용하여 요청을 받게 구현되어있습니다. 추후 로그인 및 회원 기능이 구현되게 되면 수정하도록 하겠습니다.

## 3. 관련 스크린샷을 첨부해주세요.

## 4. 완료 사항

userId를 통해 유저가 보유한 아이템을 추출하는 로직 구현
불변성을 위해 불필요한 setter삭제
프로젝트 구조에 맞게 패키지명을 api -> represent로 변경
불필요한 table이름 삭제

## 5. 추가 사항
close #7 
close #8 