### PR TITLE
[feat] #18 꽃 선택 편지 작성 api 구현

### DIFF
--- a/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
@@ -1,0 +1,27 @@
+package com.fling.fllingbe.domain.bouquet.application;
+
+
+import com.fling.fllingbe.domain.bouquet.domain.Bouquet;
+import com.fling.fllingbe.domain.bouquet.repository.BouquetRepository;
+import com.fling.fllingbe.domain.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BouquetService {
+    final private BouquetRepository bouquetRepository;
+
+    public Bouquet createNewBouquet(User user) {
+        Bouquet receiverBouquet = bouquetRepository.findByUser(user).get();
+        Bouquet newBouquet = new Bouquet().builder()
+                .user(user)
+                .ribbon(receiverBouquet.getRibbon())
+                .wrapper(receiverBouquet.getWrapper())
+                .build();
+        bouquetRepository.save(newBouquet);
+        return newBouquet;
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/domain/Bouquet.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/domain/Bouquet.java
@@ -20,7 +20,7 @@ public class Bouquet extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column
-    private Long flowerId;
+    private Long bouquetId;
 
     @ManyToOne
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/domain/Bouquet.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/domain/Bouquet.java
@@ -1,0 +1,40 @@
+package com.fling.fllingbe.domain.bouquet.domain;
+
+import com.fling.fllingbe.domain.user.domain.User;
+import com.fling.fllingbe.global.shared.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Bouquet extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long flowerId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column
+    private String ribbon;
+
+    @Column
+    private String wrapper;
+
+    @Column
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column
+    private LocalDateTime updatedAt = LocalDateTime.now();
+}

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/repository/BouquetRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/repository/BouquetRepository.java
@@ -4,9 +4,11 @@ import com.fling.fllingbe.domain.bouquet.domain.Bouquet;
 import com.fling.fllingbe.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BouquetRepository extends JpaRepository<Bouquet,Long> {
     Optional<Bouquet> findById (Long bouquetId);
     Optional<Bouquet> findByUser(User user);
+    List<Bouquet> findAllByUser(User user);
 }

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/repository/BouquetRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/repository/BouquetRepository.java
@@ -1,0 +1,12 @@
+package com.fling.fllingbe.domain.bouquet.repository;
+
+import com.fling.fllingbe.domain.bouquet.domain.Bouquet;
+import com.fling.fllingbe.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BouquetRepository extends JpaRepository<Bouquet,Long> {
+    Optional<Bouquet> findById (Long bouquetId);
+    Optional<Bouquet> findByUser(User user);
+}

--- a/src/main/java/com/fling/fllingbe/domain/flower/application/FlowerService.java
+++ b/src/main/java/com/fling/fllingbe/domain/flower/application/FlowerService.java
@@ -1,6 +1,8 @@
 package com.fling.fllingbe.domain.flower.application;
 
 
+import com.fling.fllingbe.domain.flower.domain.Flower;
+import com.fling.fllingbe.domain.flower.domain.FlowerRepository;
 import com.fling.fllingbe.domain.flower.dto.FlowerRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,8 +12,11 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class FlowerService {
+    final private FlowerRepository flowerRepository;
     public String writeLetter(FlowerRequest request, UUID id) {
-
+        Flower flower = new Flower().builder()
+                .letter(request.getLetter())
+                .build();
         return "test";
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/flower/application/FlowerService.java
+++ b/src/main/java/com/fling/fllingbe/domain/flower/application/FlowerService.java
@@ -1,0 +1,17 @@
+package com.fling.fllingbe.domain.flower.application;
+
+
+import com.fling.fllingbe.domain.flower.dto.FlowerRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class FlowerService {
+    public String writeLetter(FlowerRequest request, UUID id) {
+
+        return "test";
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/flower/application/FlowerService.java
+++ b/src/main/java/com/fling/fllingbe/domain/flower/application/FlowerService.java
@@ -1,22 +1,67 @@
 package com.fling.fllingbe.domain.flower.application;
 
 
+import com.fling.fllingbe.domain.bouquet.application.BouquetService;
+import com.fling.fllingbe.domain.bouquet.domain.Bouquet;
+import com.fling.fllingbe.domain.bouquet.repository.BouquetRepository;
 import com.fling.fllingbe.domain.flower.domain.Flower;
-import com.fling.fllingbe.domain.flower.domain.FlowerRepository;
+import com.fling.fllingbe.domain.flower.repository.FlowerRepository;
 import com.fling.fllingbe.domain.flower.dto.FlowerRequest;
+import com.fling.fllingbe.domain.item.application.CardItemService;
+import com.fling.fllingbe.domain.item.application.FlowerItemService;
+import com.fling.fllingbe.domain.item.domain.CardType;
+import com.fling.fllingbe.domain.item.domain.FlowerType;
+import com.fling.fllingbe.domain.user.domain.User;
+import com.fling.fllingbe.domain.user.exception.UserNotFoundException;
+import com.fling.fllingbe.domain.user.repository.UserRepository;
+import com.fling.fllingbe.global.error.exception.ServiceException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class FlowerService {
     final private FlowerRepository flowerRepository;
-    public String writeLetter(FlowerRequest request, UUID id) {
-        Flower flower = new Flower().builder()
-                .letter(request.getLetter())
-                .build();
-        return "test";
+    final private UserRepository userRepository;
+    final private CardItemService cardItemService;
+    final private BouquetRepository bouquetRepository;
+    final private FlowerItemService flowerItemService;
+    final private BouquetService bouquetService;
+    @Transactional
+    public String writeLetter(FlowerRequest request, UUID senderId, UUID ReceiverId) {
+        try {
+            User sender = userRepository.findByUserId(senderId).orElseThrow(()->new UserNotFoundException());
+            User receiver = userRepository.findByUserId(ReceiverId).get();
+            FlowerType flowerType = flowerItemService.minusFlowerItem(request, sender);
+            CardType cardType = cardItemService.minusCardItem(request, sender);
+            List<Flower> flowers = flowerRepository.findAllByReceiver(receiver);
+            Bouquet bouquet;
+
+            if (flowers.size() % 10 == 0) {
+                bouquet = bouquetService.createNewBouquet(receiver);
+            } else {
+                List<Bouquet> bouquets = bouquetRepository.findAllByUser(receiver);
+                bouquet = bouquets.get(bouquets.size() - 1);
+            }
+
+            Flower flower = new Flower().builder()
+                    .letter(request.getLetter())
+                    .flowerType(flowerType)
+                    .cardType(cardType)
+                    .sender(sender)
+                    .receiver(receiver)
+                    .bouquetId(bouquet)
+                    .build();
+            flowerRepository.save(flower);
+
+            return "저장에 성공하였습니다.";
+        } catch (ServiceException e) {
+            throw e;
+        }
     }
 }
+

--- a/src/main/java/com/fling/fllingbe/domain/flower/domain/Flower.java
+++ b/src/main/java/com/fling/fllingbe/domain/flower/domain/Flower.java
@@ -25,11 +25,11 @@ public class Flower extends BaseTimeEntity {
     private Long flowerId;
 
     @ManyToOne
-    @JoinColumn(name = "user_id")
+    @JoinColumn
     private User sender;
 
     @ManyToOne
-    @JoinColumn(name = "user_id")
+    @JoinColumn
     private User receiver;
 
     @OneToOne

--- a/src/main/java/com/fling/fllingbe/domain/flower/domain/Flower.java
+++ b/src/main/java/com/fling/fllingbe/domain/flower/domain/Flower.java
@@ -1,0 +1,50 @@
+package com.fling.fllingbe.domain.flower.domain;
+
+import com.fling.fllingbe.domain.item.domain.CardType;
+import com.fling.fllingbe.domain.item.domain.FlowerType;
+import com.fling.fllingbe.domain.user.domain.User;
+import com.fling.fllingbe.global.shared.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Flower extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long flowerId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User sender;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User receiver;
+
+    @OneToOne
+    @JoinColumn(name = "card_type_id")
+    private CardType cardType;
+
+    @OneToOne
+    @JoinColumn(name = "flower_type_id")
+    private FlowerType flowerType;
+
+    @Column
+    private String letter;
+
+    @Column
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column
+    private LocalDateTime updatedAt = LocalDateTime.now();
+}

--- a/src/main/java/com/fling/fllingbe/domain/flower/domain/Flower.java
+++ b/src/main/java/com/fling/fllingbe/domain/flower/domain/Flower.java
@@ -1,5 +1,6 @@
 package com.fling.fllingbe.domain.flower.domain;
 
+import com.fling.fllingbe.domain.bouquet.domain.Bouquet;
 import com.fling.fllingbe.domain.item.domain.CardType;
 import com.fling.fllingbe.domain.item.domain.FlowerType;
 import com.fling.fllingbe.domain.user.domain.User;
@@ -38,6 +39,10 @@ public class Flower extends BaseTimeEntity {
     @OneToOne
     @JoinColumn(name = "flower_type_id")
     private FlowerType flowerType;
+
+    @ManyToOne
+    @JoinColumn(name="bouquet_id")
+    private Bouquet bouquetId;
 
     @Column
     private String letter;

--- a/src/main/java/com/fling/fllingbe/domain/flower/domain/FlowerRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/flower/domain/FlowerRepository.java
@@ -1,0 +1,11 @@
+package com.fling.fllingbe.domain.flower.domain;
+
+import com.fling.fllingbe.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FlowerRepository extends JpaRepository<Flower,Long> {
+    Optional<Flower> findById(Long flowerId);
+    Optional<Flower> findByReceiver(User receiver);
+}

--- a/src/main/java/com/fling/fllingbe/domain/flower/dto/FlowerRequest.java
+++ b/src/main/java/com/fling/fllingbe/domain/flower/dto/FlowerRequest.java
@@ -1,0 +1,17 @@
+package com.fling.fllingbe.domain.flower.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FlowerRequest {
+    private String letter;
+    private String cardType;
+    private String flowerType;
+}

--- a/src/main/java/com/fling/fllingbe/domain/flower/presentation/FlowerController.java
+++ b/src/main/java/com/fling/fllingbe/domain/flower/presentation/FlowerController.java
@@ -1,19 +1,21 @@
 package com.fling.fllingbe.domain.flower.presentation;
 
 
+import com.fling.fllingbe.domain.flower.application.FlowerService;
 import com.fling.fllingbe.domain.flower.dto.FlowerRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
 public class FlowerController {
-    @PostMapping(value = "/flower")
-    public ResponseEntity<String> writeLetter(FlowerRequest flowerRequest, UUID id) {
-        return ResponseEntity.ok().body("test");
+    final private FlowerService flowerService;
+    @PostMapping(value = "/flower/{receiverId}")
+    public ResponseEntity<String> writeLetter(@RequestBody FlowerRequest flowerRequest, @PathVariable("receiverId") UUID receiverId, @RequestHeader UUID senderId) {
+        String response = flowerService.writeLetter(flowerRequest, senderId, receiverId);
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/flower/presentation/FlowerController.java
+++ b/src/main/java/com/fling/fllingbe/domain/flower/presentation/FlowerController.java
@@ -1,0 +1,19 @@
+package com.fling.fllingbe.domain.flower.presentation;
+
+
+import com.fling.fllingbe.domain.flower.dto.FlowerRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+public class FlowerController {
+    @PostMapping(value = "/flower")
+    public ResponseEntity<String> writeLetter(FlowerRequest flowerRequest, UUID id) {
+        return ResponseEntity.ok().body("test");
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/flower/repository/FlowerRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/flower/repository/FlowerRepository.java
@@ -1,11 +1,14 @@
-package com.fling.fllingbe.domain.flower.domain;
+package com.fling.fllingbe.domain.flower.repository;
 
+import com.fling.fllingbe.domain.flower.domain.Flower;
 import com.fling.fllingbe.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FlowerRepository extends JpaRepository<Flower,Long> {
     Optional<Flower> findById(Long flowerId);
     Optional<Flower> findByReceiver(User receiver);
+    List<Flower> findAllByReceiver(User receiver);
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/application/CardItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/CardItemService.java
@@ -1,11 +1,14 @@
 package com.fling.fllingbe.domain.item.application;
 
 
+import com.fling.fllingbe.domain.flower.dto.FlowerRequest;
 import com.fling.fllingbe.domain.item.domain.CardItem;
+import com.fling.fllingbe.domain.item.domain.CardType;
 import com.fling.fllingbe.domain.item.domain.FlowerItem;
 import com.fling.fllingbe.domain.item.dto.CardItemResponse;
 import com.fling.fllingbe.domain.item.dto.FlowerItemResponse;
 import com.fling.fllingbe.domain.item.repository.CardItemRepository;
+import com.fling.fllingbe.domain.item.repository.CardTypeRepository;
 import com.fling.fllingbe.domain.user.domain.User;
 import com.fling.fllingbe.domain.user.exception.UserNotFoundException;
 import com.fling.fllingbe.domain.user.repository.UserRepository;
@@ -20,6 +23,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CardItemService {
     final CardItemRepository cardItemRepository;
+    final CardTypeRepository cardTypeRepository;
     final UserRepository userRepository;
 
     public List<CardItemResponse> getCardItem(UUID userId) {
@@ -29,5 +33,25 @@ public class CardItemService {
         return  cardItems.stream()
                 .map(CardItemResponse::fromEntity)
                 .collect(Collectors.toList());
+    }
+    public CardType minusCardItem(FlowerRequest request, User user) {
+        CardType cardType = cardTypeRepository.findByCardName(request.getCardType()).get();
+        CardItem cardItem = cardItemRepository.findByUserAndCardType(user, cardType).get();
+        if (cardType.getPrice() != 0) {
+            CardItem newCardItem = new CardItem().builder()
+                    .cardItemId(cardItem.getCardItemId())
+                    .cardType(cardType)
+                    .count(cardItem.getCount() - 1)
+                    .build();
+            cardItemRepository.save(newCardItem);
+        } else {
+            CardItem newCardItem = new CardItem().builder()
+                    .cardItemId(cardItem.getCardItemId())
+                    .cardType(cardType)
+                    .count(cardItem.getCount())
+                    .build();
+            cardItemRepository.save(newCardItem);
+        }
+        return cardType;
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/application/FlowerItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/FlowerItemService.java
@@ -1,6 +1,8 @@
 package com.fling.fllingbe.domain.item.application;
 
+import com.fling.fllingbe.domain.flower.dto.FlowerRequest;
 import com.fling.fllingbe.domain.item.domain.FlowerItem;
+import com.fling.fllingbe.domain.item.domain.FlowerType;
 import com.fling.fllingbe.domain.item.dto.FlowerItemResponse;
 import com.fling.fllingbe.domain.item.repository.FlowerItemRepository;
 import com.fling.fllingbe.domain.item.repository.FlowerTypeRepository;
@@ -19,6 +21,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class FlowerItemService {
     private final FlowerItemRepository flowerItemRepository;
+    private final FlowerTypeRepository flowerTypeRepository;
     private final UserRepository userRepository;
     public List<FlowerItemResponse> getFlowerItem(UUID userId) {
         User user = userRepository.findByUserId(userId).orElseThrow(()->new UserNotFoundException());
@@ -27,5 +30,25 @@ public class FlowerItemService {
         return  flowerItems.stream()
                 .map(FlowerItemResponse::fromEntity)
                 .collect(Collectors.toList());
+    }
+    public FlowerType minusFlowerItem(FlowerRequest request, User user) {
+        FlowerType flowerType = flowerTypeRepository.findByFlowerName(request.getFlowerType()).get();
+        FlowerItem flowerItem = flowerItemRepository.findByUserAndFlowerType(user, flowerType).get();
+        if (flowerType.getPrice() != 0) {
+            FlowerItem newFlowerItem = new FlowerItem().builder()
+                    .flowerItemId(flowerItem.getFlowerItemId())
+                    .flowerType(flowerType)
+                    .count(flowerItem.getCount() - 1)
+                    .build();
+            flowerItemRepository.save(newFlowerItem);
+        } else {
+            FlowerItem newFlowerItem = new FlowerItem().builder()
+                    .flowerItemId(flowerItem.getFlowerItemId())
+                    .flowerType(flowerType)
+                    .count(flowerItem.getCount())
+                    .build();
+            flowerItemRepository.save(newFlowerItem);
+        }
+        return flowerType;
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/application/FlowerItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/FlowerItemService.java
@@ -22,7 +22,7 @@ public class FlowerItemService {
     private final UserRepository userRepository;
     public List<FlowerItemResponse> getFlowerItem(UUID userId) {
         User user = userRepository.findByUserId(userId).orElseThrow(()->new UserNotFoundException());
-        List<FlowerItem> flowerItems = flowerItemRepository.findByUser(user);
+        List<FlowerItem> flowerItems = flowerItemRepository.findAllByUser(user);
 
         return  flowerItems.stream()
                 .map(FlowerItemResponse::fromEntity)

--- a/src/main/java/com/fling/fllingbe/domain/item/repository/CardItemRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/repository/CardItemRepository.java
@@ -1,6 +1,7 @@
 package com.fling.fllingbe.domain.item.repository;
 
 import com.fling.fllingbe.domain.item.domain.CardItem;
+import com.fling.fllingbe.domain.item.domain.CardType;
 import com.fling.fllingbe.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,5 @@ import java.util.Optional;
 public interface CardItemRepository extends JpaRepository<CardItem,Long> {
     Optional<CardItem> findById(Long CardItemId);
     List<CardItem> findByUser(User user);
+    Optional<CardItem> findByUserAndCardType(User user, CardType cardType);
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/repository/CardTypeRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/repository/CardTypeRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface CardTypeRepository extends JpaRepository<CardType,Long> {
     Optional<CardType> findById(Long cardTypeId);
+    Optional<CardType> findByCardName(String cardName);
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/repository/FlowerItemRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/repository/FlowerItemRepository.java
@@ -1,6 +1,7 @@
 package com.fling.fllingbe.domain.item.repository;
 
 import com.fling.fllingbe.domain.item.domain.FlowerItem;
+import com.fling.fllingbe.domain.item.domain.FlowerType;
 import com.fling.fllingbe.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,8 +9,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface FlowerItemRepository extends JpaRepository<FlowerItem, Long> {
-    Optional<FlowerItem>
-    findById(Long flowerItemId);
+    Optional<FlowerItem> findById(Long flowerItemId);
     List<FlowerItem> findAllByUser(User user);
     Optional<FlowerItem> findByUser(User user);
+    Optional<FlowerItem> findByUserAndFlowerType(User user,FlowerType flowerType);
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/repository/FlowerItemRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/repository/FlowerItemRepository.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface FlowerItemRepository extends JpaRepository<FlowerItem, Long> {
-    Optional<FlowerItem> findById(Long flowerItemId);
-    List<FlowerItem> findByUser(User user);
+    Optional<FlowerItem>
+    findById(Long flowerItemId);
+    List<FlowerItem> findAllByUser(User user);
+    Optional<FlowerItem> findByUser(User user);
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/repository/FlowerTypeRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/repository/FlowerTypeRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface FlowerTypeRepository extends JpaRepository<FlowerType, Long> {
     Optional<FlowerType> findById(Long flowerTypeId);
+    Optional<FlowerType> findByFlowerName(String flowerName);
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

<br>

꽃을 선택하고 편지를 작성하는 기능을 추가했습니다.

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

아직 로그인이 구현되지 않아 테스트가 불가합니다. 추가적인 예외처리 및 테스트는 토큰, 로그인 기능이 구현 된 후 진행될 예정입니다.

## 3. 관련 스크린샷을 첨부해주세요.

<br>

해당사항 없습니다.

## 4. 완료 사항

<br>

사용자가 작성한 편지 및 선택한 아이템을 db에 저장하는 로직 구현
소비 아이템인 경우 유저의 아이템 정보에서 개수를 감소시키는 로직 구현
한 꽃다발 당 개수가 일정 개수를 넘어갔을 경우 새 꽃다발을 생성하여 저장하는 로직 구현

## 5. 추가 사항

close #15 