### PR TITLE
[fix] #21 아이템 타입과 아이템 사이의 관계 수정

### DIFF
--- a/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class BouquetService {
-    final private BouquetRepository bouquetRepository;
+    private final  BouquetRepository bouquetRepository;
 
     public Bouquet createNewBouquet(User user) {
         Bouquet receiverBouquet = bouquetRepository.findByUser(user).get();

--- a/src/main/java/com/fling/fllingbe/domain/flower/application/FlowerService.java
+++ b/src/main/java/com/fling/fllingbe/domain/flower/application/FlowerService.java
@@ -25,12 +25,12 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class FlowerService {
-    final private FlowerRepository flowerRepository;
-    final private UserRepository userRepository;
-    final private CardItemService cardItemService;
-    final private BouquetRepository bouquetRepository;
-    final private FlowerItemService flowerItemService;
-    final private BouquetService bouquetService;
+    private final FlowerRepository flowerRepository;
+    private final UserRepository userRepository;
+    private final CardItemService cardItemService;
+    private final BouquetRepository bouquetRepository;
+    private final FlowerItemService flowerItemService;
+    private final BouquetService bouquetService;
     @Transactional
     public String writeLetter(FlowerRequest request, UUID senderId, UUID ReceiverId) {
         try {
@@ -39,9 +39,10 @@ public class FlowerService {
             FlowerType flowerType = flowerItemService.minusFlowerItem(request, sender);
             CardType cardType = cardItemService.minusCardItem(request, sender);
             List<Flower> flowers = flowerRepository.findAllByReceiver(receiver);
+            System.out.println(flowers.size());
             Bouquet bouquet;
 
-            if (flowers.size() % 10 == 0) {
+            if (flowers.size() % 10 == 0 && flowers.size() != 0) {
                 bouquet = bouquetService.createNewBouquet(receiver);
             } else {
                 List<Bouquet> bouquets = bouquetRepository.findAllByUser(receiver);

--- a/src/main/java/com/fling/fllingbe/domain/flower/domain/Flower.java
+++ b/src/main/java/com/fling/fllingbe/domain/flower/domain/Flower.java
@@ -32,15 +32,15 @@ public class Flower extends BaseTimeEntity {
     @JoinColumn
     private User receiver;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "card_type_id")
     private CardType cardType;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "flower_type_id")
     private FlowerType flowerType;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="bouquet_id")
     private Bouquet bouquetId;
 

--- a/src/main/java/com/fling/fllingbe/domain/flower/presentation/FlowerController.java
+++ b/src/main/java/com/fling/fllingbe/domain/flower/presentation/FlowerController.java
@@ -13,8 +13,8 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class FlowerController {
     final private FlowerService flowerService;
-    @PostMapping(value = "/flower/{receiverId}")
-    public ResponseEntity<String> writeLetter(@RequestBody FlowerRequest flowerRequest, @PathVariable("receiverId") UUID receiverId, @RequestHeader UUID senderId) {
+    @PostMapping(value = "/flower/{receiverId}/{senderId}")
+    public ResponseEntity<String> writeLetter(@RequestBody FlowerRequest flowerRequest, @PathVariable("receiverId") UUID receiverId, @PathVariable("senderId") UUID senderId) {
         String response = flowerService.writeLetter(flowerRequest, senderId, receiverId);
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/CardItem.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/CardItem.java
@@ -23,7 +23,7 @@ public class CardItem {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "card_type_id")
     private CardType cardType;
 

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/DecoItem.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/DecoItem.java
@@ -23,7 +23,7 @@ public class DecoItem {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "deco_type_id")
     private DecoType decoType;
 

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerItem.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerItem.java
@@ -21,7 +21,7 @@ public class FlowerItem {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "flower_type_id")
     private FlowerType flowerType;
 


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

<br>

아이템 타입과 아이템 엔티티 사이의 관계를 수정

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

아이템 타입 엔티티와 엔티티 사이의 관계가 잘못 지정되어 있었습니다
꽃과 아이템 타입 엔티티 사이의 관계도 잘못되어 있어 수정하였습니다.
최초 꽃을 생성할때 꽃다발이 자동으로 생성되는 현상을 발견하여 수정하였습니다.

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항

<br>

아이템 타입 엔티티와 엔티티 사이의 관계를 many to one 으로 수정 
꽃과 아이템 타입 엔티티 사이의 관계를 many to one으로 수정
최초 꽃을 생성할때 꽃다발이 자동으로 생성되는 현상 수정

## 5. 추가 사항
close #20 