### PR TITLE
[feat] #36 꽃다발 업데이트 기능 추가

### DIFF
--- a/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
@@ -10,6 +10,10 @@ import com.fling.fllingbe.domain.bouquet.repository.BouquetRepository;
 import com.fling.fllingbe.domain.flower.domain.Flower;
 import com.fling.fllingbe.domain.flower.dto.FlowerInfo;
 import com.fling.fllingbe.domain.flower.repository.FlowerRepository;
+import com.fling.fllingbe.domain.item.domain.RibbonType;
+import com.fling.fllingbe.domain.item.domain.WrapperType;
+import com.fling.fllingbe.domain.item.repository.RibbonRepository;
+import com.fling.fllingbe.domain.item.repository.WrapperTypeRepository;
 import com.fling.fllingbe.domain.user.domain.User;
 import com.fling.fllingbe.domain.user.exception.UserNotFoundException;
 import com.fling.fllingbe.domain.user.repository.UserRepository;
@@ -18,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
+import java.sql.Wrapper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -29,12 +34,14 @@ public class BouquetService {
     private final UserRepository userRepository;
     private final FlowerRepository flowerRepository;
     private final JwtProvider jwtProvider;
+    private final RibbonRepository ribbonRepository;
+    private final WrapperTypeRepository wrapperTypeRepository;
     public Bouquet createNewBouquet(User user) {
         Bouquet receiverBouquet = bouquetRepository.findByUser(user).get();
         Bouquet newBouquet = new Bouquet().builder()
                 .user(user)
-                .ribbon(receiverBouquet.getRibbon())
-                .wrapper(receiverBouquet.getWrapper())
+                .ribbonType(receiverBouquet.getRibbonType())
+                .wrapperType(receiverBouquet.getWrapperType())
                 .build();
         bouquetRepository.save(newBouquet);
         return newBouquet;
@@ -42,10 +49,12 @@ public class BouquetService {
 
     public String createFirstBouquet(UUID id , CreateBouquetRequest request) {
         User user = userRepository.findById(id).orElseThrow(()-> new UserNotFoundException());
+        RibbonType ribbonType = ribbonRepository.findByRibbonName(request.getRibbon()).get();
+        WrapperType wrapperType = wrapperTypeRepository.findByWrapperName(request.getWrapper()).get();
         Bouquet newBouquet = new Bouquet().builder()
                 .user(user)
-                .ribbon(request.getRibbon())
-                .wrapper(request.getWrapper())
+                .ribbonType(ribbonType)
+                .wrapperType(wrapperType)
                 .build();
         bouquetRepository.save(newBouquet);
         return "꽃다발 생성에 성공하였습니다.";
@@ -67,8 +76,8 @@ public class BouquetService {
         return getBouquetResponse;
     }
     public BouquetDesign getBouquetDesign(Bouquet bouquet) {
-        BouquetDesign bouquetDesign = new BouquetDesign(bouquet.getWrapper()
-                ,bouquet.getRibbon()
+        BouquetDesign bouquetDesign = new BouquetDesign(bouquet.getWrapperType().getWrapperName()
+                ,bouquet.getRibbonType().getRibbonName()
                 ,bouquet.getDecoItem1().getDecoTypeName()
                 ,bouquet.getDecoItem2().getDecoTypeName()
                 ,bouquet.getDecoItem3().getDecoTypeName());

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
@@ -42,11 +42,14 @@ public class BouquetService {
     private final DecoItemRepository decoItemRepository;
     private final DecoItemService decoItemService;
     public Bouquet createNewBouquet(User user) {
-        Bouquet receiverBouquet = bouquetRepository.findByUser(user).get();
+        List<Bouquet> receiverBouquets = bouquetRepository.findAllByUser(user);
         Bouquet newBouquet = new Bouquet().builder()
                 .user(user)
-                .ribbonType(receiverBouquet.getRibbonType())
-                .wrapperType(receiverBouquet.getWrapperType())
+                .decoItem1(receiverBouquets.get(0).getDecoItem1())
+                .decoItem2(receiverBouquets.get(0).getDecoItem2())
+                .decoItem3(receiverBouquets.get(0).getDecoItem3())
+                .ribbonType(receiverBouquets.get(0).getRibbonType())
+                .wrapperType(receiverBouquets.get(0).getWrapperType())
                 .build();
         bouquetRepository.save(newBouquet);
         return newBouquet;
@@ -58,6 +61,9 @@ public class BouquetService {
         WrapperType wrapperType = wrapperTypeRepository.findByWrapperName(request.getWrapper()).get();
         Bouquet newBouquet = new Bouquet().builder()
                 .user(user)
+                .decoItem1(decoTypeRepository.findByDecoTypeName("아이템 1").get())
+                .decoItem2(decoTypeRepository.findByDecoTypeName("아이템 2").get())
+                .decoItem3(decoTypeRepository.findByDecoTypeName("아이템 3").get())
                 .ribbonType(ribbonType)
                 .wrapperType(wrapperType)
                 .build();

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/domain/Bouquet.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/domain/Bouquet.java
@@ -2,6 +2,8 @@ package com.fling.fllingbe.domain.bouquet.domain;
 
 import com.fling.fllingbe.domain.item.domain.DecoItem;
 import com.fling.fllingbe.domain.item.domain.DecoType;
+import com.fling.fllingbe.domain.item.domain.RibbonType;
+import com.fling.fllingbe.domain.item.domain.WrapperType;
 import com.fling.fllingbe.domain.user.domain.User;
 import com.fling.fllingbe.global.shared.domain.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -10,6 +12,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.sql.Wrapper;
 import java.time.LocalDateTime;
 
 
@@ -40,9 +43,11 @@ public class Bouquet extends BaseTimeEntity {
     @JoinColumn
     private DecoType decoItem3;
 
-    @Column
-    private String ribbon;
+    @ManyToOne
+    @JoinColumn
+    private RibbonType ribbonType;
 
-    @Column
-    private String wrapper;
+    @ManyToOne
+    @JoinColumn
+    private WrapperType wrapperType;
 }

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/dto/UpdateBouquetRequest.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/dto/UpdateBouquetRequest.java
@@ -1,0 +1,17 @@
+package com.fling.fllingbe.domain.bouquet.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UpdateBouquetRequest {
+    private String wrapper;
+    private String ribbon;
+    private String item1;
+    private String item2;
+    private String item3;
+}

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/presentation/BouquetController.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/presentation/BouquetController.java
@@ -4,6 +4,7 @@ package com.fling.fllingbe.domain.bouquet.presentation;
 import com.fling.fllingbe.domain.bouquet.application.BouquetService;
 import com.fling.fllingbe.domain.bouquet.dto.CreateBouquetRequest;
 import com.fling.fllingbe.domain.bouquet.dto.GetBouquetResponse;
+import com.fling.fllingbe.domain.bouquet.dto.UpdateBouquetRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -15,15 +16,22 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class BouquetController {
     private final BouquetService bouquetService;
+
     @PostMapping("/bouquet/{id}")
-    public ResponseEntity<String> createBouquet(@PathVariable("id")UUID id, @RequestBody CreateBouquetRequest request) {
+    public ResponseEntity<String> createBouquet(@PathVariable("id") UUID id, @RequestBody CreateBouquetRequest request) {
         String response = bouquetService.createFirstBouquet(id, request);
         return ResponseEntity.ok().body(response);
     }
+
     @GetMapping("/bouquet")
     public ResponseEntity<GetBouquetResponse> getBouquet(Authentication authentication) {
         GetBouquetResponse getBouquetResponse = bouquetService.getBouquetResponse(authentication);
         return ResponseEntity.ok().body(getBouquetResponse);
     }
 
+    @PatchMapping("/bouquet")
+    public ResponseEntity<String> updateBouquet(@RequestBody UpdateBouquetRequest request,Authentication authentication) {
+        String response = bouquetService.updateBouquet(request, authentication);
+        return ResponseEntity.ok().body(response);
+    }
 }

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/presentation/BouquetController.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/presentation/BouquetController.java
@@ -18,7 +18,7 @@ public class BouquetController {
     @PostMapping("/bouquet/{id}")
     public ResponseEntity<String> createBouquet(@PathVariable("id")UUID id, @RequestBody CreateBouquetRequest request) {
         String response = bouquetService.createFirstBouquet(id, request);
-        return ResponseEntity.ok().body("꽃다발 생성에 성공하였습니다.");
+        return ResponseEntity.ok().body(response);
     }
     @GetMapping("/bouquet")
     public ResponseEntity<GetBouquetResponse> getBouquet(Authentication authentication) {

--- a/src/main/java/com/fling/fllingbe/domain/item/application/CardItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/CardItemService.java
@@ -21,7 +21,8 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class CardItemService {
+public class
+CardItemService {
     final CardItemRepository cardItemRepository;
     final CardTypeRepository cardTypeRepository;
     final UserRepository userRepository;

--- a/src/main/java/com/fling/fllingbe/domain/item/application/DecoItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/DecoItemService.java
@@ -1,16 +1,21 @@
 package com.fling.fllingbe.domain.item.application;
 
+import com.fling.fllingbe.domain.bouquet.domain.Bouquet;
+import com.fling.fllingbe.domain.bouquet.dto.UpdateBouquetRequest;
 import com.fling.fllingbe.domain.item.domain.DecoItem;
+import com.fling.fllingbe.domain.item.domain.DecoType;
 import com.fling.fllingbe.domain.item.domain.FlowerItem;
 import com.fling.fllingbe.domain.item.dto.DecoItemResponse;
 import com.fling.fllingbe.domain.item.dto.FlowerItemResponse;
 import com.fling.fllingbe.domain.item.repository.DecoItemRepository;
+import com.fling.fllingbe.domain.item.repository.DecoTypeRepository;
 import com.fling.fllingbe.domain.user.domain.User;
 import com.fling.fllingbe.domain.user.exception.UserNotFoundException;
 import com.fling.fllingbe.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -20,7 +25,7 @@ import java.util.stream.Collectors;
 public class DecoItemService {
     private final DecoItemRepository decoItemRepository;
     private final UserRepository userRepository;
-
+    private final DecoTypeRepository decoTypeRepository;
     public List<DecoItemResponse> getDecoItem(String userEmail) {
         User user = userRepository.findByEmail(userEmail).orElseThrow(()->new UserNotFoundException());
         List<DecoItem> decoItems = decoItemRepository.findByUser(user);
@@ -28,5 +33,50 @@ public class DecoItemService {
         return  decoItems.stream()
                 .map(DecoItemResponse::fromEntity)
                 .toList();
+    }
+    public List<DecoItem> toTrue(User user, UpdateBouquetRequest request) {
+        List<DecoItem> decoItemList = new ArrayList<>();
+        DecoType decoType1 = decoTypeRepository.findByDecoTypeName(request.getItem1()).get();
+        DecoType decoType2 = decoTypeRepository.findByDecoTypeName(request.getItem2()).get();
+        DecoType decoType3 = decoTypeRepository.findByDecoTypeName(request.getItem3()).get();
+        DecoItem decoItem1 = decoItemRepository.findByUserAndDecoType(user,decoType1).get();
+        DecoItem decoItem2 = decoItemRepository.findByUserAndDecoType(user,decoType2).get();
+        DecoItem decoItem3 = decoItemRepository.findByUserAndDecoType(user,decoType3).get();
+        DecoItem newDecoItem1 = new DecoItem().builder()
+                .decoItemId(decoItem1.getDecoItemId())
+                .decoType(decoType1)
+                .user(user)
+                .isUsing(true)
+                .build();
+        decoItemRepository.save(newDecoItem1);
+        DecoItem newDecoItem2 = new DecoItem().builder()
+                .decoItemId(decoItem2.getDecoItemId())
+                .decoType(decoType2)
+                .user(user)
+                .isUsing(true)
+                .build();
+        decoItemRepository.save(newDecoItem2);
+        DecoItem newDecoItem3 = new DecoItem().builder()
+                .decoItemId(decoItem3.getDecoItemId())
+                .decoType(decoType3)
+                .user(user)
+                .isUsing(true)
+                .build();
+        decoItemRepository.save(newDecoItem3);
+        decoItemList.add(newDecoItem1);
+        decoItemList.add(newDecoItem2);
+        decoItemList.add(newDecoItem3);
+        return decoItemList;
+    }
+    public void toFalse(User user,List<DecoItem> decoItemList) {
+        for (DecoItem decoItem : decoItemList) {
+            DecoItem newDecoItem = new DecoItem().builder()
+                    .decoItemId(decoItem.getDecoItemId())
+                    .decoType(decoItem.getDecoType())
+                    .user(user)
+                    .isUsing(false)
+                    .build();
+            decoItemRepository.save(newDecoItem);
+        }
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/CardType.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/CardType.java
@@ -22,5 +22,8 @@ public class CardType {
     private String cardName;
 
     @Column
+    private String description;
+
+    @Column
     private Long price;
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/DecoType.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/DecoType.java
@@ -25,5 +25,8 @@ public class DecoType {
     private Long position;
 
     @Column
+    private String description;
+
+    @Column
     private Long price;
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerType.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerType.java
@@ -18,6 +18,9 @@ public class FlowerType {
     @Column(name = "flower_name")
     private String flowerName;
 
+    @Column
+    private String description;
+
     @Column(name = "price")
     private Long price;
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/RibbonType.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/RibbonType.java
@@ -1,0 +1,23 @@
+package com.fling.fllingbe.domain.item.domain;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class RibbonType {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long ribbonTypeId;
+
+    @Column
+    private String ribbonName;
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/WrapperType.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/WrapperType.java
@@ -1,0 +1,23 @@
+package com.fling.fllingbe.domain.item.domain;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class WrapperType {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long wrapperTypeId;
+
+    @Column
+    private String wrapperName;
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/repository/DecoItemRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/repository/DecoItemRepository.java
@@ -1,6 +1,7 @@
 package com.fling.fllingbe.domain.item.repository;
 
 import com.fling.fllingbe.domain.item.domain.DecoItem;
+import com.fling.fllingbe.domain.item.domain.DecoType;
 import com.fling.fllingbe.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,7 @@ import java.util.Optional;
 public interface DecoItemRepository extends JpaRepository<DecoItem,Long> {
     Optional<DecoItem> findById(Long decoItemId);
     List<DecoItem> findByUser(User user);
+    Optional<DecoItem> findByDecoType(DecoType decoType);
+    Optional<DecoItem> findByUserAndDecoType(User user, DecoType decoType);
+    List<DecoItem> findAllByUserAndIsUsing(User user,boolean isUsing);
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/repository/DecoTypeRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/repository/DecoTypeRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface DecoTypeRepository extends JpaRepository<DecoType, Long> {
     Optional<DecoType> findById(Long decoTypeId);
+    Optional<DecoType> findByDecoTypeName(String decoTypeName);
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/repository/RibbonRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/repository/RibbonRepository.java
@@ -1,0 +1,10 @@
+package com.fling.fllingbe.domain.item.repository;
+
+import com.fling.fllingbe.domain.item.domain.RibbonType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RibbonRepository extends JpaRepository<RibbonType, Long> {
+    Optional<RibbonType> findByRibbonName(String ribbonName);
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/repository/WrapperTypeRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/repository/WrapperTypeRepository.java
@@ -1,0 +1,10 @@
+package com.fling.fllingbe.domain.item.repository;
+
+import com.fling.fllingbe.domain.item.domain.WrapperType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface WrapperTypeRepository extends JpaRepository<WrapperType,Long> {
+    Optional<WrapperType> findByWrapperName(String wrapperName);
+}


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

<br>

꽃다발 업데이트 기능을 추가하였습니다. 
프론트 요구에 따라 리본엔티티, 포장지 엔티티를 분리하는 코드를 추가하였습니다.
추가로 아이템 엔티티에 descripstion 필드를 추가하였습니다. 추후 아이템 도감 api에 사용 될 예정입니다.

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

없습니다.

## 3. 관련 스크린샷을 첨부해주세요.

<br>

<img width="748" alt="스크린샷 2024-01-14 오후 7 07 54" src="https://github.com/Leets-Official/Fling-BE/assets/92284769/906e24c2-34a3-4157-9c29-1b6e2ba392ef">


## 4. 완료 사항

<br>

꽃다발의 디자인을 변경하는 로직 구현
리본엔티티, 포장지 엔티티를 분리하는 코드를 추가
아이템 엔티티에 descripstion 필드를 추가하였습니다. 

## 5. 추가 사항

close #35 