### PR TITLE
[fix] #43 데코아이템 엔티티 수정

### DIFF
--- a/src/main/java/com/fling/fllingbe/domain/item/domain/DecoItem.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/DecoItem.java
@@ -29,7 +29,4 @@ public class DecoItem {
 
     @Column
     private Boolean isUsing;
-
-    @Column
-    private Long count;
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/DecoType.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/DecoType.java
@@ -22,9 +22,6 @@ public class DecoType {
     private String decoTypeName;
 
     @Column
-    private Long position;
-
-    @Column
     private String description;
 
     @Column

--- a/src/main/java/com/fling/fllingbe/domain/item/dto/DecoItemResponse.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/dto/DecoItemResponse.java
@@ -12,9 +12,8 @@ import lombok.Getter;
 public class DecoItemResponse {
     private String decoType;
     private Boolean isUsing;
-    private Long Position;
 
     public static DecoItemResponse fromEntity(DecoItem decoItem) {
-        return new DecoItemResponse(decoItem.getDecoType().getDecoTypeName(), decoItem.getIsUsing(),decoItem.getDecoType().getPosition());
+        return new DecoItemResponse(decoItem.getDecoType().getDecoTypeName(), decoItem.getIsUsing());
     }
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

<br>

데코아이템 엔티티를 수정하였습니다.

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

기존에 생각한 로직은 아이템 별로 3가지 포지션을 가지게 테이블을 수정 하는 것 이었는데 모든 데코아이템은 모든 위치에 있을 수 있으므로 사용 유무만 표시하면 된다고 생각하여 position 필드를 아이템 타입과 아이템 테이블에서 삭제하였습니다.

## 3. 관련 스크린샷을 첨부해주세요.

<br>

<img width="847" alt="스크린샷 2024-01-14 오후 11 37 04" src="https://github.com/Leets-Official/Fling-BE/assets/92284769/65a32bd2-f466-4ede-bf06-f87528285627">

정상적용된 모습입니다.

<img width="712" alt="스크린샷 2024-01-14 오후 11 38 28" src="https://github.com/Leets-Official/Fling-BE/assets/92284769/da17795c-e507-46c0-8717-daa79900c799">



## 4. 완료 사항

<br>

데코 아이템  엔티티 수정

## 5. 추가 사항

close #42 