### PR TITLE
[feat] #44 전체 아이템 가져오기 기능 추가

### DIFF
--- a/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
@@ -35,7 +35,6 @@ public class BouquetService {
     private final  BouquetRepository bouquetRepository;
     private final UserRepository userRepository;
     private final FlowerRepository flowerRepository;
-    private final JwtProvider jwtProvider;
     private final RibbonRepository ribbonRepository;
     private final WrapperTypeRepository wrapperTypeRepository;
     private final DecoTypeRepository decoTypeRepository;

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
@@ -59,9 +59,9 @@ public class BouquetService {
         User user = userRepository.findByEmail(authentication.getName()).orElseThrow(()-> new UserNotFoundException());
         Bouquet newBouquet = new Bouquet().builder()
                 .user(user)
-                .decoItem1(decoTypeRepository.findByDecoTypeName("아이템 1").get())
-                .decoItem2(decoTypeRepository.findByDecoTypeName("아이템 2").get())
-                .decoItem3(decoTypeRepository.findByDecoTypeName("아이템 3").get())
+                .decoItem1(decoTypeRepository.findByDecoTypeName("undefined").get())
+                .decoItem2(decoTypeRepository.findByDecoTypeName("undefined").get())
+                .decoItem3(decoTypeRepository.findByDecoTypeName("undefined").get())
                 .ribbonType(ribbonRepository.findByRibbonName(request.getRibbon()).get())
                 .wrapperType(wrapperTypeRepository.findByWrapperName(request.getWrapper()).get())
                 .build();

--- a/src/main/java/com/fling/fllingbe/domain/flower/application/FlowerService.java
+++ b/src/main/java/com/fling/fllingbe/domain/flower/application/FlowerService.java
@@ -45,7 +45,7 @@ public class FlowerService {
             System.out.println(flowers.size());
             Bouquet bouquet;
 
-            if (flowers.size() % 10 == 0 && flowers.size() != 0) {
+            if (flowers.size() % 5 == 0 && flowers.size() != 0) {
                 bouquet = bouquetService.createNewBouquet(receiver);
             } else {
                 List<Bouquet> bouquets = bouquetRepository.findAllByUser(receiver);

--- a/src/main/java/com/fling/fllingbe/domain/item/application/CardItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/CardItemService.java
@@ -65,6 +65,7 @@ CardItemService {
             CardItem cardItem = CardItem.builder()
                     .cardType(cardType)
                     .user(user)
+                    .owned(cardType.getPrice() == 0)
                     .count(0L)
                     .build();
             cardItemRepository.save(cardItem);

--- a/src/main/java/com/fling/fllingbe/domain/item/application/CardItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/CardItemService.java
@@ -57,4 +57,15 @@ CardItemService {
         }
         return cardType;
     }
+    public void createDefaultCardItem(User user) {
+        List<CardType> cardTypeList = cardTypeRepository.findAll();
+        for (CardType cardType : cardTypeList) {
+            CardItem cardItem = CardItem.builder()
+                    .cardType(cardType)
+                    .user(user)
+                    .count(0L)
+                    .build();
+            cardItemRepository.save(cardItem);
+        }
+    }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/application/CardItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/CardItemService.java
@@ -7,6 +7,8 @@ import com.fling.fllingbe.domain.item.domain.CardType;
 import com.fling.fllingbe.domain.item.domain.FlowerItem;
 import com.fling.fllingbe.domain.item.dto.CardItemResponse;
 import com.fling.fllingbe.domain.item.dto.FlowerItemResponse;
+import com.fling.fllingbe.domain.item.dto.GetItemRequest;
+import com.fling.fllingbe.domain.item.dto.GetItemResponse;
 import com.fling.fllingbe.domain.item.repository.CardItemRepository;
 import com.fling.fllingbe.domain.item.repository.CardTypeRepository;
 import com.fling.fllingbe.domain.user.domain.User;
@@ -67,5 +69,14 @@ CardItemService {
                     .build();
             cardItemRepository.save(cardItem);
         }
+    }
+
+    public GetItemResponse getCardItemInfo(GetItemRequest getItemRequest) {
+        CardType cardType = cardTypeRepository.findById(getItemRequest.getId()).get();
+        GetItemResponse getItemResponse = GetItemResponse.builder()
+                .itemName(cardType.getCardName())
+                .description(cardType.getDescription())
+                .build();
+        return getItemResponse;
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/application/DecoItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/DecoItemService.java
@@ -87,6 +87,7 @@ public class DecoItemService {
             DecoItem decoItem = DecoItem.builder()
                     .user(user)
                     .decoType(decoType)
+                    .owned(decoType.getPrice() == 0)
                     .isUsing(false)
                     .build();
             decoItemRepository.save(decoItem);

--- a/src/main/java/com/fling/fllingbe/domain/item/application/DecoItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/DecoItemService.java
@@ -79,4 +79,15 @@ public class DecoItemService {
             decoItemRepository.save(newDecoItem);
         }
     }
+    public void createDefaultDecoItem(User user) {
+        List<DecoType> decoTypeList = decoTypeRepository.findAll();
+        for (DecoType decoType : decoTypeList) {
+            DecoItem decoItem = DecoItem.builder()
+                    .user(user)
+                    .decoType(decoType)
+                    .isUsing(false)
+                    .build();
+            decoItemRepository.save(decoItem);
+        }
+    }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/application/DecoItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/DecoItemService.java
@@ -7,6 +7,8 @@ import com.fling.fllingbe.domain.item.domain.DecoType;
 import com.fling.fllingbe.domain.item.domain.FlowerItem;
 import com.fling.fllingbe.domain.item.dto.DecoItemResponse;
 import com.fling.fllingbe.domain.item.dto.FlowerItemResponse;
+import com.fling.fllingbe.domain.item.dto.GetItemRequest;
+import com.fling.fllingbe.domain.item.dto.GetItemResponse;
 import com.fling.fllingbe.domain.item.repository.DecoItemRepository;
 import com.fling.fllingbe.domain.item.repository.DecoTypeRepository;
 import com.fling.fllingbe.domain.user.domain.User;
@@ -89,5 +91,13 @@ public class DecoItemService {
                     .build();
             decoItemRepository.save(decoItem);
         }
+    }
+    public GetItemResponse getDecoItemInfo(GetItemRequest request) {
+        DecoType decoType = decoTypeRepository.findById(request.getId()).get();
+        GetItemResponse getItemResponse = GetItemResponse.builder()
+                .itemName(decoType.getDecoTypeName())
+                .description(decoType.getDescription())
+                .build();
+        return getItemResponse;
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/application/FlowerItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/FlowerItemService.java
@@ -58,11 +58,11 @@ public class FlowerItemService {
     public void createDefaultFlowerItem(User user) {
         List<FlowerType> flowerItemList = flowerTypeRepository.findAll();
         for (FlowerType flowerType : flowerItemList) {
-            System.out.println(flowerType.getFlowerName());
             FlowerItem flowerItem = FlowerItem.builder()
                     .user(user)
                     .count(0L)
                     .flowerType(flowerType)
+                    .owned(flowerType.getPrice() == 0)
                     .build();
             flowerItemRepository.save(flowerItem);
         }

--- a/src/main/java/com/fling/fllingbe/domain/item/application/FlowerItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/FlowerItemService.java
@@ -4,6 +4,8 @@ import com.fling.fllingbe.domain.flower.dto.FlowerRequest;
 import com.fling.fllingbe.domain.item.domain.FlowerItem;
 import com.fling.fllingbe.domain.item.domain.FlowerType;
 import com.fling.fllingbe.domain.item.dto.FlowerItemResponse;
+import com.fling.fllingbe.domain.item.dto.GetItemRequest;
+import com.fling.fllingbe.domain.item.dto.GetItemResponse;
 import com.fling.fllingbe.domain.item.repository.FlowerItemRepository;
 import com.fling.fllingbe.domain.item.repository.FlowerTypeRepository;
 import com.fling.fllingbe.domain.user.domain.User;
@@ -64,5 +66,14 @@ public class FlowerItemService {
                     .build();
             flowerItemRepository.save(flowerItem);
         }
+    }
+
+    public GetItemResponse getFlowerItemInfo(GetItemRequest request) {
+        FlowerType flowerType = flowerTypeRepository.findById(request.getId()).get();
+        GetItemResponse getItemResponse = GetItemResponse.builder()
+                .itemName(flowerType.getFlowerName())
+                .description(flowerType.getDescription())
+                .build();
+        return getItemResponse;
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/application/FlowerItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/FlowerItemService.java
@@ -53,4 +53,16 @@ public class FlowerItemService {
         }
         return flowerType;
     }
+    public void createDefaultFlowerItem(User user) {
+        List<FlowerType> flowerItemList = flowerTypeRepository.findAll();
+        for (FlowerType flowerType : flowerItemList) {
+            System.out.println(flowerType.getFlowerName());
+            FlowerItem flowerItem = FlowerItem.builder()
+                    .user(user)
+                    .count(0L)
+                    .flowerType(flowerType)
+                    .build();
+            flowerItemRepository.save(flowerItem);
+        }
+    }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/application/ItemsService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/ItemsService.java
@@ -7,7 +7,11 @@ import com.fling.fllingbe.domain.item.dto.DecoItemInfo;
 import com.fling.fllingbe.domain.item.dto.FlowerItemInfo;
 import com.fling.fllingbe.domain.item.dto.GetItemsResponse;
 import com.fling.fllingbe.domain.item.repository.*;
+import com.fling.fllingbe.domain.user.domain.User;
+import com.fling.fllingbe.domain.user.exception.UserNotFoundException;
+import com.fling.fllingbe.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,16 +20,22 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ItemsService {
     private final FlowerTypeRepository flowerTypeRepository;
+    private final FlowerItemRepository flowerItemRepository;
     private final DecoTypeRepository decoTypeRepository;
-    private final CardTypeRepository cardTypeRepository;
-    public GetItemsResponse getItems() {
-        List<FlowerType> flowerTypeList = flowerTypeRepository.findAll();
-        List<FlowerItemInfo> flowerItemInfoList = flowerTypeList.stream().map(FlowerItemInfo::fromEntity).toList();
-        Long ignoreDecoTypeId = decoTypeRepository.findByDecoTypeName("undefined").get().getDecoTypeId();
-        List<DecoType> decoTypeList = decoTypeRepository.findAllByDecoTypeIdIsNot(ignoreDecoTypeId);
-        List<DecoItemInfo> decoItemInfoList = decoTypeList.stream().map(DecoItemInfo::fromEntity).toList();
-        List<CardType> cardTypeList = cardTypeRepository.findAll();
-        List<CardItemInfo> cardItemInfoList = cardTypeList.stream().map(CardItemInfo::fromEntity).toList();
+    private final CardItemRepository cardItemRepository;
+    private final UserRepository userRepository;
+    private final DecoItemRepository decoItemRepository;
+    public GetItemsResponse getItems(Authentication authentication) {
+        User user = userRepository.findByEmail(authentication.getName()).orElseThrow(()-> new UserNotFoundException());
+        List<FlowerItem> flowerItemList = flowerItemRepository.findAllByUser(user);
+        List<FlowerItemInfo> flowerItemInfoList = flowerItemList.stream().map(FlowerItemInfo::fromEntity).toList();
+
+        DecoType ignoreDecoType = decoTypeRepository.findByDecoTypeName("undefined").get();
+        List<DecoItem> decoItemList = decoItemRepository.findAllByUserAndDecoTypeIsNot(user,ignoreDecoType);
+        List<DecoItemInfo> decoItemInfoList = decoItemList.stream().map(DecoItemInfo::fromEntity).toList();
+
+        List<CardItem> cardItemList = cardItemRepository.findByUser(user);
+        List<CardItemInfo> cardItemInfoList = cardItemList.stream().map(CardItemInfo::fromEntity).toList();
         return new GetItemsResponse(flowerItemInfoList,decoItemInfoList,cardItemInfoList);
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/application/ItemsService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/ItemsService.java
@@ -21,7 +21,8 @@ public class ItemsService {
     public GetItemsResponse getItems() {
         List<FlowerType> flowerTypeList = flowerTypeRepository.findAll();
         List<FlowerItemInfo> flowerItemInfoList = flowerTypeList.stream().map(FlowerItemInfo::fromEntity).toList();
-        List<DecoType> decoTypeList = decoTypeRepository.findAllByDecoTypeIdIsNot(1L);
+        Long ignoreDecoTypeId = decoTypeRepository.findByDecoTypeName("undefined").get().getDecoTypeId();
+        List<DecoType> decoTypeList = decoTypeRepository.findAllByDecoTypeIdIsNot(ignoreDecoTypeId);
         List<DecoItemInfo> decoItemInfoList = decoTypeList.stream().map(DecoItemInfo::fromEntity).toList();
         List<CardType> cardTypeList = cardTypeRepository.findAll();
         List<CardItemInfo> cardItemInfoList = cardTypeList.stream().map(CardItemInfo::fromEntity).toList();

--- a/src/main/java/com/fling/fllingbe/domain/item/application/ItemsService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/ItemsService.java
@@ -1,0 +1,30 @@
+package com.fling.fllingbe.domain.item.application;
+
+
+import com.fling.fllingbe.domain.item.domain.*;
+import com.fling.fllingbe.domain.item.dto.CardItemInfo;
+import com.fling.fllingbe.domain.item.dto.DecoItemInfo;
+import com.fling.fllingbe.domain.item.dto.FlowerItemInfo;
+import com.fling.fllingbe.domain.item.dto.GetItemsResponse;
+import com.fling.fllingbe.domain.item.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ItemsService {
+    private final FlowerTypeRepository flowerTypeRepository;
+    private final DecoTypeRepository decoTypeRepository;
+    private final CardTypeRepository cardTypeRepository;
+    public GetItemsResponse getItems() {
+        List<FlowerType> flowerTypeList = flowerTypeRepository.findAll();
+        List<FlowerItemInfo> flowerItemInfoList = flowerTypeList.stream().map(FlowerItemInfo::fromEntity).toList();
+        List<DecoType> decoTypeList = decoTypeRepository.findAllByDecoTypeIdIsNot(1L);
+        List<DecoItemInfo> decoItemInfoList = decoTypeList.stream().map(DecoItemInfo::fromEntity).toList();
+        List<CardType> cardTypeList = cardTypeRepository.findAll();
+        List<CardItemInfo> cardItemInfoList = cardTypeList.stream().map(CardItemInfo::fromEntity).toList();
+        return new GetItemsResponse(flowerItemInfoList,decoItemInfoList,cardItemInfoList);
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/application/ItemsService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/ItemsService.java
@@ -2,10 +2,7 @@ package com.fling.fllingbe.domain.item.application;
 
 
 import com.fling.fllingbe.domain.item.domain.*;
-import com.fling.fllingbe.domain.item.dto.CardItemInfo;
-import com.fling.fllingbe.domain.item.dto.DecoItemInfo;
-import com.fling.fllingbe.domain.item.dto.FlowerItemInfo;
-import com.fling.fllingbe.domain.item.dto.GetItemsResponse;
+import com.fling.fllingbe.domain.item.dto.*;
 import com.fling.fllingbe.domain.item.repository.*;
 import com.fling.fllingbe.domain.user.domain.User;
 import com.fling.fllingbe.domain.user.exception.UserNotFoundException;
@@ -14,17 +11,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ItemsService {
-    private final FlowerTypeRepository flowerTypeRepository;
     private final FlowerItemRepository flowerItemRepository;
     private final DecoTypeRepository decoTypeRepository;
     private final CardItemRepository cardItemRepository;
     private final UserRepository userRepository;
     private final DecoItemRepository decoItemRepository;
+    private final RibbonRepository ribbonRepository;
+    private final WrapperTypeRepository wrapperTypeRepository;
     public GetItemsResponse getItems(Authentication authentication) {
         User user = userRepository.findByEmail(authentication.getName()).orElseThrow(()-> new UserNotFoundException());
         List<FlowerItem> flowerItemList = flowerItemRepository.findAllByUser(user);
@@ -37,5 +36,31 @@ public class ItemsService {
         List<CardItem> cardItemList = cardItemRepository.findByUser(user);
         List<CardItemInfo> cardItemInfoList = cardItemList.stream().map(CardItemInfo::fromEntity).toList();
         return new GetItemsResponse(flowerItemInfoList,decoItemInfoList,cardItemInfoList);
+    }
+    public BouquetItemResponse getBouquetItemResponse() {
+        List<BouquetItemInfo> ribbonInfoList = new ArrayList<>();
+        List<RibbonType> ribbonTypeList = ribbonRepository.findAll();
+        for (RibbonType ribbonType : ribbonTypeList) {
+            BouquetItemInfo bouquetItemInfo = BouquetItemInfo.builder()
+                    .id(ribbonType.getRibbonTypeId())
+                    .type(ribbonType.getRibbonName())
+                    .build();
+            ribbonInfoList.add(bouquetItemInfo);
+        }
+
+        List<BouquetItemInfo> wrapperInfoList = new ArrayList<>();
+        List<WrapperType> wrapperTypeList = wrapperTypeRepository.findAll();
+        for (WrapperType wrapperType : wrapperTypeList) {
+            BouquetItemInfo bouquetItemInfo = BouquetItemInfo.builder()
+                    .id(wrapperType.getWrapperTypeId())
+                    .type(wrapperType.getWrapperName())
+                    .build();
+            wrapperInfoList.add(bouquetItemInfo);
+        }
+        BouquetItemResponse bouquetItemResponse = BouquetItemResponse.builder()
+                .ribbon(ribbonInfoList)
+                .wrapper(wrapperInfoList)
+                .build();
+        return bouquetItemResponse;
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/CardItem.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/CardItem.java
@@ -28,5 +28,8 @@ public class CardItem {
     private CardType cardType;
 
     @Column
+    private boolean owned;
+
+    @Column
     private Long count;
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/DecoItem.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/DecoItem.java
@@ -28,5 +28,8 @@ public class DecoItem {
     private DecoType decoType;
 
     @Column
+    private boolean owned;
+
+    @Column
     private Boolean isUsing;
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerItem.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/FlowerItem.java
@@ -26,5 +26,8 @@ public class FlowerItem {
     private FlowerType flowerType;
 
     @Column
+    private boolean owned;
+
+    @Column
     private Long count;
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/dto/BouquetItemInfo.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/dto/BouquetItemInfo.java
@@ -1,0 +1,14 @@
+package com.fling.fllingbe.domain.item.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class BouquetItemInfo {
+    private Long id;
+    private String type;
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/dto/BouquetItemResponse.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/dto/BouquetItemResponse.java
@@ -1,0 +1,16 @@
+package com.fling.fllingbe.domain.item.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class BouquetItemResponse {
+    List<BouquetItemInfo> wrapper;
+    List<BouquetItemInfo> ribbon;
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/dto/CardItemInfo.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/dto/CardItemInfo.java
@@ -13,11 +13,14 @@ import lombok.Getter;
 public class CardItemInfo {
     private Long id;
     private String type;
-
-    public static CardItemInfo fromEntity(CardType cardType) {
+    private boolean owned;
+    private Long amount;
+    public static CardItemInfo fromEntity(CardItem cardItem) {
         CardItemInfo cardItemInfo = CardItemInfo.builder()
-                .id(cardType.getCardTypeId())
-                .type(cardType.getCardName())
+                .id(cardItem.getCardType().getCardTypeId())
+                .type(cardItem.getCardType().getCardName())
+                .owned(cardItem.isOwned())
+                .amount(cardItem.getCount())
                 .build();
         return cardItemInfo;
     }

--- a/src/main/java/com/fling/fllingbe/domain/item/dto/CardItemInfo.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/dto/CardItemInfo.java
@@ -1,0 +1,24 @@
+package com.fling.fllingbe.domain.item.dto;
+
+
+import com.fling.fllingbe.domain.item.domain.CardItem;
+import com.fling.fllingbe.domain.item.domain.CardType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CardItemInfo {
+    private Long id;
+    private String type;
+
+    public static CardItemInfo fromEntity(CardType cardType) {
+        CardItemInfo cardItemInfo = CardItemInfo.builder()
+                .id(cardType.getCardTypeId())
+                .type(cardType.getCardName())
+                .build();
+        return cardItemInfo;
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/dto/DecoItemInfo.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/dto/DecoItemInfo.java
@@ -1,0 +1,25 @@
+package com.fling.fllingbe.domain.item.dto;
+
+
+import com.fling.fllingbe.domain.item.domain.DecoItem;
+import com.fling.fllingbe.domain.item.domain.DecoType;
+import com.fling.fllingbe.domain.item.domain.FlowerItem;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DecoItemInfo {
+    private Long id;
+    private String type;
+
+    public static DecoItemInfo fromEntity(DecoType decoType) {
+        DecoItemInfo decoItemInfo = DecoItemInfo.builder()
+                .id(decoType.getDecoTypeId())
+                .type(decoType.getDecoTypeName())
+                .build();
+        return decoItemInfo;
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/dto/DecoItemInfo.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/dto/DecoItemInfo.java
@@ -14,11 +14,12 @@ import lombok.Getter;
 public class DecoItemInfo {
     private Long id;
     private String type;
-
-    public static DecoItemInfo fromEntity(DecoType decoType) {
+    private boolean owned;
+    public static DecoItemInfo fromEntity(DecoItem decoItem) {
         DecoItemInfo decoItemInfo = DecoItemInfo.builder()
-                .id(decoType.getDecoTypeId())
-                .type(decoType.getDecoTypeName())
+                .id(decoItem.getDecoItemId())
+                .type(decoItem.getDecoType().getDecoTypeName())
+                .owned(decoItem.isOwned())
                 .build();
         return decoItemInfo;
     }

--- a/src/main/java/com/fling/fllingbe/domain/item/dto/FlowerItemInfo.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/dto/FlowerItemInfo.java
@@ -1,0 +1,24 @@
+package com.fling.fllingbe.domain.item.dto;
+
+
+import com.fling.fllingbe.domain.item.domain.FlowerItem;
+import com.fling.fllingbe.domain.item.domain.FlowerType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FlowerItemInfo {
+    private Long id;
+    private String type;
+
+    public static FlowerItemInfo fromEntity(FlowerType flowerType) {
+        FlowerItemInfo flowerItemInfo = FlowerItemInfo.builder()
+                .id(flowerType.getFlowerTypeId())
+                .type(flowerType.getFlowerName())
+                .build();
+        return flowerItemInfo;
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/dto/FlowerItemInfo.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/dto/FlowerItemInfo.java
@@ -13,11 +13,14 @@ import lombok.Getter;
 public class FlowerItemInfo {
     private Long id;
     private String type;
-
-    public static FlowerItemInfo fromEntity(FlowerType flowerType) {
+    private boolean owned;
+    private Long amount;
+    public static FlowerItemInfo fromEntity(FlowerItem flowerItem) {
         FlowerItemInfo flowerItemInfo = FlowerItemInfo.builder()
-                .id(flowerType.getFlowerTypeId())
-                .type(flowerType.getFlowerName())
+                .id(flowerItem.getFlowerType().getFlowerTypeId())
+                .type(flowerItem.getFlowerType().getFlowerName())
+                .owned(flowerItem.isOwned())
+                .amount(flowerItem.getCount())
                 .build();
         return flowerItemInfo;
     }

--- a/src/main/java/com/fling/fllingbe/domain/item/dto/GetItemRequest.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/dto/GetItemRequest.java
@@ -1,0 +1,14 @@
+package com.fling.fllingbe.domain.item.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GetItemRequest {
+    private Long id;
+    public GetItemRequest(){};
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/dto/GetItemResponse.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/dto/GetItemResponse.java
@@ -1,0 +1,14 @@
+package com.fling.fllingbe.domain.item.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GetItemResponse {
+    private String itemName;
+    private String description;
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/dto/GetItemsResponse.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/dto/GetItemsResponse.java
@@ -1,0 +1,18 @@
+package com.fling.fllingbe.domain.item.dto;
+
+
+import com.fling.fllingbe.domain.item.domain.DecoItem;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GetItemsResponse {
+    private List<FlowerItemInfo> flowers;
+    private List<DecoItemInfo> decoItems;
+    private List<CardItemInfo> cardItems;
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/presentation/CardItemController.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/presentation/CardItemController.java
@@ -3,12 +3,16 @@ package com.fling.fllingbe.domain.item.presentation;
 
 import com.fling.fllingbe.domain.item.application.CardItemService;
 import com.fling.fllingbe.domain.item.dto.CardItemResponse;
+import com.fling.fllingbe.domain.item.dto.GetItemRequest;
+import com.fling.fllingbe.domain.item.dto.GetItemResponse;
+import com.fling.fllingbe.domain.item.dto.GetItemsResponse;
 import com.fling.fllingbe.domain.item.repository.CardItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -23,5 +27,11 @@ public class CardItemController {
     public ResponseEntity<List<CardItemResponse>> getCardItem(Authentication authentication) {
         List<CardItemResponse> cardItems = cardItemService.getCardItem(authentication.getName());
         return ResponseEntity.ok().body(cardItems);
+    }
+
+    @GetMapping(value = "/carditem-info")
+    public ResponseEntity<GetItemResponse> getCardItemInfo(@RequestBody GetItemRequest getItemRequest) {
+        GetItemResponse getItemResponse = cardItemService.getCardItemInfo(getItemRequest);
+        return ResponseEntity.ok().body(getItemResponse);
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/presentation/DecoItemController.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/presentation/DecoItemController.java
@@ -2,11 +2,14 @@ package com.fling.fllingbe.domain.item.presentation;
 
 import com.fling.fllingbe.domain.item.application.DecoItemService;
 import com.fling.fllingbe.domain.item.dto.DecoItemResponse;
+import com.fling.fllingbe.domain.item.dto.GetItemRequest;
+import com.fling.fllingbe.domain.item.dto.GetItemResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -21,5 +24,11 @@ public class DecoItemController {
     public ResponseEntity<List<DecoItemResponse>> getDecoItem(Authentication authentication) {
         List<DecoItemResponse> decoItemResponses = decoItemService.getDecoItem(authentication.getName());
         return ResponseEntity.ok().body(decoItemResponses);
+    }
+
+    @GetMapping(value = "/decoitem-info")
+    public ResponseEntity<GetItemResponse> getDecoItemInfo(@RequestBody GetItemRequest request) {
+        GetItemResponse getItemResponse = decoItemService.getDecoItemInfo(request);
+        return ResponseEntity.ok().body(getItemResponse);
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/presentation/FlowerItemController.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/presentation/FlowerItemController.java
@@ -2,11 +2,15 @@ package com.fling.fllingbe.domain.item.presentation;
 
 import com.fling.fllingbe.domain.item.application.FlowerItemService;
 import com.fling.fllingbe.domain.item.dto.FlowerItemResponse;
+import com.fling.fllingbe.domain.item.dto.GetItemRequest;
+import com.fling.fllingbe.domain.item.dto.GetItemResponse;
+import com.fling.fllingbe.domain.item.dto.GetItemsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -20,5 +24,10 @@ public class FlowerItemController {
     public ResponseEntity<List<FlowerItemResponse>> getFlowerItem(Authentication authentication) {
         List<FlowerItemResponse> flowerItems = flowerItemService.getFlowerItem(authentication.getName());
         return ResponseEntity.ok().body(flowerItems);
+    }
+    @GetMapping("/floweritem-info")
+    public ResponseEntity<GetItemResponse> getFlowerItemInfo(@RequestBody GetItemRequest request) {
+        GetItemResponse getItemResponse = flowerItemService.getFlowerItemInfo(request);
+        return ResponseEntity.ok().body(getItemResponse);
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/presentation/ItemsController.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/presentation/ItemsController.java
@@ -1,0 +1,22 @@
+package com.fling.fllingbe.domain.item.presentation;
+
+
+import com.fling.fllingbe.domain.item.application.ItemsService;
+import com.fling.fllingbe.domain.item.dto.GetItemsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ItemsController {
+    private final ItemsService itemsService;
+
+    @GetMapping("/items")
+    public ResponseEntity<GetItemsResponse> getItems() {
+        GetItemsResponse getItemsResponse = itemsService.getItems();
+        return ResponseEntity.ok().body(getItemsResponse);
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/presentation/ItemsController.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/presentation/ItemsController.java
@@ -15,8 +15,8 @@ public class ItemsController {
     private final ItemsService itemsService;
 
     @GetMapping("/items")
-    public ResponseEntity<GetItemsResponse> getItems() {
-        GetItemsResponse getItemsResponse = itemsService.getItems();
+    public ResponseEntity<GetItemsResponse> getItems(Authentication authentication) {
+        GetItemsResponse getItemsResponse = itemsService.getItems(authentication);
         return ResponseEntity.ok().body(getItemsResponse);
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/presentation/ItemsController.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/presentation/ItemsController.java
@@ -2,6 +2,7 @@ package com.fling.fllingbe.domain.item.presentation;
 
 
 import com.fling.fllingbe.domain.item.application.ItemsService;
+import com.fling.fllingbe.domain.item.dto.BouquetItemResponse;
 import com.fling.fllingbe.domain.item.dto.GetItemsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,5 +19,11 @@ public class ItemsController {
     public ResponseEntity<GetItemsResponse> getItems(Authentication authentication) {
         GetItemsResponse getItemsResponse = itemsService.getItems(authentication);
         return ResponseEntity.ok().body(getItemsResponse);
+    }
+
+    @GetMapping("/bouquet-items")
+    public ResponseEntity<BouquetItemResponse> getBouquetItems() {
+        BouquetItemResponse bouquetItemResponse = itemsService.getBouquetItemResponse();
+        return ResponseEntity.ok().body(bouquetItemResponse);
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/repository/DecoItemRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/repository/DecoItemRepository.java
@@ -14,4 +14,5 @@ public interface DecoItemRepository extends JpaRepository<DecoItem,Long> {
     Optional<DecoItem> findByDecoType(DecoType decoType);
     Optional<DecoItem> findByUserAndDecoType(User user, DecoType decoType);
     List<DecoItem> findAllByUserAndIsUsing(User user,boolean isUsing);
+    List<DecoItem> findAllByUserAndDecoTypeIsNot(User user, DecoType decoType);
 }

--- a/src/main/java/com/fling/fllingbe/domain/item/repository/DecoTypeRepository.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/repository/DecoTypeRepository.java
@@ -3,9 +3,11 @@ package com.fling.fllingbe.domain.item.repository;
 import com.fling.fllingbe.domain.item.domain.DecoType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DecoTypeRepository extends JpaRepository<DecoType, Long> {
     Optional<DecoType> findById(Long decoTypeId);
     Optional<DecoType> findByDecoTypeName(String decoTypeName);
+    List<DecoType> findAllByDecoTypeIdIsNot(Long decoTypeId);
 }

--- a/src/main/java/com/fling/fllingbe/domain/user/application/UserService.java
+++ b/src/main/java/com/fling/fllingbe/domain/user/application/UserService.java
@@ -2,7 +2,9 @@ package com.fling.fllingbe.domain.user.application;
 
 import com.fling.fllingbe.domain.coin.domain.Coin;
 import com.fling.fllingbe.domain.coin.repository.CoinRepository;
+import com.fling.fllingbe.domain.item.application.DecoItemService;
 import com.fling.fllingbe.domain.item.application.FlowerItemService;
+import com.fling.fllingbe.domain.item.domain.DecoItem;
 import com.fling.fllingbe.domain.user.domain.User;
 import com.fling.fllingbe.domain.user.dto.RefreshRequest;
 import com.fling.fllingbe.domain.user.dto.TestUserRequest;
@@ -37,6 +39,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final CoinRepository coinRepository;
     private final FlowerItemService flowerItemService;
+    private final DecoItemService decoItemService;
     private final JwtProvider jwtProvider;
 
     public ResponseEntity<UserResponse> login(UserRequest request) throws Exception {
@@ -159,6 +162,7 @@ public class UserService {
         userRepository.save(user);
         coinRepository.save(coin);
         flowerItemService.createDefaultFlowerItem(user);
+        decoItemService.createDefaultDecoItem(user);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/user/application/UserService.java
+++ b/src/main/java/com/fling/fllingbe/domain/user/application/UserService.java
@@ -2,6 +2,7 @@ package com.fling.fllingbe.domain.user.application;
 
 import com.fling.fllingbe.domain.coin.domain.Coin;
 import com.fling.fllingbe.domain.coin.repository.CoinRepository;
+import com.fling.fllingbe.domain.item.application.CardItemService;
 import com.fling.fllingbe.domain.item.application.DecoItemService;
 import com.fling.fllingbe.domain.item.application.FlowerItemService;
 import com.fling.fllingbe.domain.item.domain.DecoItem;
@@ -40,6 +41,7 @@ public class UserService {
     private final CoinRepository coinRepository;
     private final FlowerItemService flowerItemService;
     private final DecoItemService decoItemService;
+    private final CardItemService cardItemService;
     private final JwtProvider jwtProvider;
 
     public ResponseEntity<UserResponse> login(UserRequest request) throws Exception {
@@ -163,6 +165,7 @@ public class UserService {
         coinRepository.save(coin);
         flowerItemService.createDefaultFlowerItem(user);
         decoItemService.createDefaultDecoItem(user);
+        cardItemService.createDefaultCardItem(user);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/user/application/UserService.java
+++ b/src/main/java/com/fling/fllingbe/domain/user/application/UserService.java
@@ -2,6 +2,7 @@ package com.fling.fllingbe.domain.user.application;
 
 import com.fling.fllingbe.domain.coin.domain.Coin;
 import com.fling.fllingbe.domain.coin.repository.CoinRepository;
+import com.fling.fllingbe.domain.item.application.FlowerItemService;
 import com.fling.fllingbe.domain.user.domain.User;
 import com.fling.fllingbe.domain.user.dto.RefreshRequest;
 import com.fling.fllingbe.domain.user.dto.TestUserRequest;
@@ -35,6 +36,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final CoinRepository coinRepository;
+    private final FlowerItemService flowerItemService;
     private final JwtProvider jwtProvider;
 
     public ResponseEntity<UserResponse> login(UserRequest request) throws Exception {
@@ -156,6 +158,7 @@ public class UserService {
                 .build();
         userRepository.save(user);
         coinRepository.save(coin);
+        flowerItemService.createDefaultFlowerItem(user);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

<br>

유저가 가지고 있는 전체 아이템을 가져오는 기능을 추가하였습니다.
모든 꽃다발 아이템을 가져오는 기능을 추가하였습니다.
아이템 엔티티에 owned 속성을 추가하였습니다
특정 아이템 id를 이용하여 아이템의 이름과 정보를 전달하는 기능을 추가하였습니다.
회원가입시 유저에게 아이템을 부여하는 로직을 추가하였습니다.
최초 꽃다발 생성시 decoItem은 undefined로 설정됩니다.

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

1. 상점 구매 api에 구매시 소유자의 아이템에 owned 속성을 true로 설정하는 로직이 필요할 것 같습니다.

2. decoType db에 기본적으로 undefined라는 아이템을 추가해 두어야 할 것 같습니다

## 3. 관련 스크린샷을 첨부해주세요.

<br>

포장지와 리본 아이템을 모두 가져오는 기능

<img width="722" alt="스크린샷 2024-01-15 오전 11 42 44" src="https://github.com/Leets-Official/Fling-BE/assets/92284769/852cc800-1185-4ab4-bf89-28ea37c66376">

시스템 상 모든 아이템을 가져오는 기능(유저가 가지고 있을 경우 owned : true 를 리턴함

<img width="729" alt="스크린샷 2024-01-15 오전 11 44 10" src="https://github.com/Leets-Official/Fling-BE/assets/92284769/a32fe70a-3ca7-4807-8384-ff3e78adc5d3">

아이템 id를 통해 아이템이름과 정보를 가져오는 기능

<img width="590" alt="스크린샷 2024-01-15 오전 11 46 51" src="https://github.com/Leets-Official/Fling-BE/assets/92284769/769e5997-27ab-4dfe-9550-d99931f36cc0">


## 4. 완료 사항

<br>

유저가 가지고 있는 전체 아이템을 가져오는 기능을 추가
유저가 가지고 있지 않은 아이템도 count :0, owned: false 상태로 리턴하는 로직 구현
모든 꽃다발 아이템을 가져오는 기능을 추가
아이템 엔티티에 owned 속성을 추가
특정 아이템 id를 이용하여 아이템의 이름과 정보를 전달하는 로직 구현
회원가입시 유저에게 아이템을 부여하는 로직을 추가
최초 꽃다발 생성시 decoItem은 undefined로 설정되도록 로직 구현

## 5. 추가 사항

close #38 