### PR TITLE
[fix] #55 꽃다발 읽어오기 수정

### DIFF
--- a/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
@@ -66,6 +66,14 @@ public class BouquetService {
                 .wrapperType(wrapperTypeRepository.findByWrapperName(request.getWrapper()).get())
                 .build();
         bouquetRepository.save(newBouquet);
+        User newUser = User.builder()
+                .userId(user.getUserId())
+                .email(user.getEmail())
+                .dDay(request.getDDay())
+                .nickname(user.getNickname())
+                .description(request.getBouquetName())
+                .build();
+        userRepository.save(newUser);
         return "꽃다발 생성에 성공하였습니다.";
     }
     public GetBouquetResponse getBouquetResponse(UUID userId) {

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
@@ -67,8 +67,8 @@ public class BouquetService {
         bouquetRepository.save(newBouquet);
         return "꽃다발 생성에 성공하였습니다.";
     }
-    public GetBouquetResponse getBouquetResponse(Authentication authentication) {
-        User user = userRepository.findByEmail(authentication.getName()).orElseThrow(()-> new UserNotFoundException());
+    public GetBouquetResponse getBouquetResponse(UUID userId) {
+        User user = userRepository.findByUserId(userId).orElseThrow(()-> new UserNotFoundException());
         List<Bouquet> bouquets = bouquetRepository.findAllByUser(user);
         if (bouquets.size() != 0) {
             List<BouquetInfo> bouquetInfos = new ArrayList<>();

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
@@ -25,6 +25,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import java.sql.Wrapper;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -81,10 +82,12 @@ public class BouquetService {
                 BouquetInfo bouquetInfo = new BouquetInfo(bouquet.getBouquetId(), flowerInfoList);
                 bouquetInfos.add(bouquetInfo);
             }
-            GetBouquetResponse getBouquetResponse = new GetBouquetResponse(bouquetDesign, bouquetInfos);
+            String description = user.getDescription();
+            LocalDateTime dDay = user.getDDay();
+            GetBouquetResponse getBouquetResponse = new GetBouquetResponse(description,dDay,bouquetDesign, bouquetInfos);
             return getBouquetResponse;
         } else {
-            GetBouquetResponse getBouquetResponse = new GetBouquetResponse(null,null);
+            GetBouquetResponse getBouquetResponse = new GetBouquetResponse(null,null,null,null);
             return getBouquetResponse;
         }
     }

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
@@ -70,18 +70,23 @@ public class BouquetService {
     public GetBouquetResponse getBouquetResponse(Authentication authentication) {
         User user = userRepository.findByEmail(authentication.getName()).orElseThrow(()-> new UserNotFoundException());
         List<Bouquet> bouquets = bouquetRepository.findAllByUser(user);
-        List<BouquetInfo> bouquetInfos = new ArrayList<>();
-        BouquetDesign bouquetDesign = getBouquetDesign(bouquets.get(0));
-        for(Bouquet bouquet : bouquets){
-            List<Flower> flowers = flowerRepository.findAllByBouquetId(bouquet);
-            List<FlowerInfo> flowerInfoList = flowers.stream()
-                    .map(FlowerInfo::fromEntity)
-                    .toList();
-            BouquetInfo bouquetInfo = new BouquetInfo(bouquet.getBouquetId(), flowerInfoList);
-            bouquetInfos.add(bouquetInfo);
+        if (bouquets.size() != 0) {
+            List<BouquetInfo> bouquetInfos = new ArrayList<>();
+            BouquetDesign bouquetDesign = getBouquetDesign(bouquets.get(0));
+            for (Bouquet bouquet : bouquets) {
+                List<Flower> flowers = flowerRepository.findAllByBouquetId(bouquet);
+                List<FlowerInfo> flowerInfoList = flowers.stream()
+                        .map(FlowerInfo::fromEntity)
+                        .toList();
+                BouquetInfo bouquetInfo = new BouquetInfo(bouquet.getBouquetId(), flowerInfoList);
+                bouquetInfos.add(bouquetInfo);
+            }
+            GetBouquetResponse getBouquetResponse = new GetBouquetResponse(bouquetDesign, bouquetInfos);
+            return getBouquetResponse;
+        } else {
+            GetBouquetResponse getBouquetResponse = new GetBouquetResponse(null,null);
+            return getBouquetResponse;
         }
-        GetBouquetResponse getBouquetResponse = new GetBouquetResponse(bouquetDesign,bouquetInfos);
-        return getBouquetResponse;
     }
     public BouquetDesign getBouquetDesign(Bouquet bouquet) {
         BouquetDesign bouquetDesign = new BouquetDesign(bouquet.getWrapperType().getWrapperName()

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/application/BouquetService.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Service;
 import java.sql.Wrapper;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -95,7 +96,7 @@ public class BouquetService {
             GetBouquetResponse getBouquetResponse = new GetBouquetResponse(description,dDay,bouquetDesign, bouquetInfos);
             return getBouquetResponse;
         } else {
-            GetBouquetResponse getBouquetResponse = new GetBouquetResponse(null,null,null,null);
+            GetBouquetResponse getBouquetResponse = new GetBouquetResponse(null,null,null, Collections.emptyList());
             return getBouquetResponse;
         }
     }

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/dto/CreateBouquetRequest.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/dto/CreateBouquetRequest.java
@@ -5,10 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @AllArgsConstructor
 public class CreateBouquetRequest {
-    String wrapper;
-    String ribbon;
+    private LocalDateTime dDay;
+    private String bouquetName;
+    private String wrapper;
+    private String ribbon;
 }

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/dto/GetBouquetResponse.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/dto/GetBouquetResponse.java
@@ -13,5 +13,5 @@ import java.util.List;
 @AllArgsConstructor
 public class GetBouquetResponse {
     private BouquetDesign bouquetDesign;
-    private List<BouquetInfo> bouquets;
+    private List bouquets;
 }

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/dto/GetBouquetResponse.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/dto/GetBouquetResponse.java
@@ -16,5 +16,5 @@ public class GetBouquetResponse {
     private String description;
     private LocalDateTime dDay;
     private BouquetDesign bouquetDesign;
-    private List bouquets;
+    private List<BouquetInfo> bouquets;
 }

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/dto/GetBouquetResponse.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/dto/GetBouquetResponse.java
@@ -6,12 +6,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
 @Builder
 @AllArgsConstructor
 public class GetBouquetResponse {
+    private String description;
+    private LocalDateTime dDay;
     private BouquetDesign bouquetDesign;
     private List bouquets;
 }

--- a/src/main/java/com/fling/fllingbe/domain/bouquet/presentation/BouquetController.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/presentation/BouquetController.java
@@ -22,9 +22,9 @@ public class BouquetController {
         return ResponseEntity.ok().body("꽃다발 생성에 성공하였습니다.");
     }
 
-    @GetMapping("/bouquet")
-    public ResponseEntity<GetBouquetResponse> getBouquet(Authentication authentication) {
-        GetBouquetResponse getBouquetResponse = bouquetService.getBouquetResponse(authentication);
+    @GetMapping("/bouquet/{id}")
+    public ResponseEntity<GetBouquetResponse> getBouquet(@PathVariable(value = "id") UUID userId) {
+        GetBouquetResponse getBouquetResponse = bouquetService.getBouquetResponse(userId);
         return ResponseEntity.ok().body(getBouquetResponse);
     }
 

--- a/src/main/java/com/fling/fllingbe/domain/item/application/FlowerItemService.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/application/FlowerItemService.java
@@ -39,6 +39,7 @@ public class FlowerItemService {
                     .flowerItemId(flowerItem.getFlowerItemId())
                     .user(user)
                     .flowerType(flowerType)
+                    .owned(true)
                     .count(flowerItem.getCount() - 1)
                     .build();
             flowerItemRepository.save(newFlowerItem);
@@ -47,6 +48,7 @@ public class FlowerItemService {
                     .flowerItemId(flowerItem.getFlowerItemId())
                     .user(user)
                     .flowerType(flowerType)
+                    .owned(true)
                     .count(flowerItem.getCount())
                     .build();
             flowerItemRepository.save(newFlowerItem);


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

<br>

1. 꽃다발을 읽어올 때 유저가 꽃다발을 가지고 있지 않을 경우 null을 반환하도록 코드를 변경하였습니다.
2. 꽃다발을 읽어 올때 이제 꽃다발 이름과 d-day를 함께 반환 합니다
3. 꽃다발을 최초 생성 할 떄 꽃다발 이름과 d-day도 함께 요청하도록 변경하였습니다.
4. 꽃다발을 가져올 때 토큰이 아닌 url의 userid에서 가져오게 변경하였습니다.

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

없습니다

## 3. 관련 스크린샷을 첨부해주세요.

<br>

최초 꽃다발 생성 전

<img width="740" alt="스크린샷 2024-01-17 오후 3 43 26" src="https://github.com/Leets-Official/Fling-BE/assets/92284769/d0f9147d-6eb7-4019-bb8b-857e17c80cf0">

꽃다발 생성 후

<img width="732" alt="스크린샷 2024-01-17 오후 3 43 05" src="https://github.com/Leets-Official/Fling-BE/assets/92284769/92a1de2c-db7d-4cec-b698-43eb34a2e340">



## 4. 완료 사항

<br>

1. createBouquetRequest 에 description, d-day 추가
2. getbouquetResponse에 description, d-day 추가
3. 꽃다발이 하나도 없을 경우 예외 처리 코드 추가
4. getBouquet요청시 request를 pathvariable로 수정

## 5. 추가 사항

close #52 