### PR TITLE
[fix] #58 dday가 response에 카멜케이스로 전달되지 않는 현상 수정

### DIFF
--- a/src/main/java/com/fling/fllingbe/domain/bouquet/dto/GetBouquetResponse.java
+++ b/src/main/java/com/fling/fllingbe/domain/bouquet/dto/GetBouquetResponse.java
@@ -1,5 +1,6 @@
 package com.fling.fllingbe.domain.bouquet.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fling.fllingbe.domain.bouquet.domain.Bouquet;
 import com.fling.fllingbe.domain.user.domain.User;
 import lombok.AllArgsConstructor;
@@ -14,7 +15,8 @@ import java.util.List;
 @AllArgsConstructor
 public class GetBouquetResponse {
     private String description;
-    private LocalDateTime dDay;
+    @JsonProperty(value = "dDay")
+    private LocalDateTime dday;
     private BouquetDesign bouquetDesign;
     private List<BouquetInfo> bouquets;
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

<br>
getBouquet의 response에서 dDay가 카멜케이스로 변경되지 않는 현상을 발견했습니다.

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

@Jsonproperty 어노테이션을 이용하여 수정하였지만 dDay라는 변수명이 있을 경우 새로운 필드를 하나 더 생성하는 현상이 발견되어 변수명을 불가피하게 dday로 수정하였습니다. 

## 3. 관련 스크린샷을 첨부해주세요.

<br>

<img width="746" alt="스크린샷 2024-01-18 오후 7 08 14" src="https://github.com/Leets-Official/Fling-BE/assets/92284769/c54b3c66-755c-46c7-b0de-4fc4797a1eef">

## 4. 완료 사항

<br>

dday의 response에 카멜케이스로 전달되지 않는 현상 수정

## 5. 추가 사항

close #56 