### PR TITLE
[fix] #62 꽃 구매 시 owned 값 변경

### DIFF
--- a/src/main/java/com/fling/fllingbe/domain/store/application/StoreService.java
+++ b/src/main/java/com/fling/fllingbe/domain/store/application/StoreService.java
@@ -43,6 +43,7 @@ public class StoreService {
         coinRepository.save(userCoin);
 
         flowerItem.setCount(flowerItem.getCount() + request.getCount());
+        flowerItem.setOwned(true);
         flowerItemRepository.save(flowerItem);
     }
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- /store/flower API 호출 시, 꽃 구매 시 owned 값을 true로 변경
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<br>
<img width="1014" alt="img1" src="https://github.com/Leets-Official/Fling-BE/assets/70849467/55553093-9f3d-444f-a15f-2a8d55ff092b">


## 4. 완료 사항
- 꽃 구매 시, 해당 꽃의 owned 값을 true로 변경하였습니다.
<br>

## 5. 추가 사항
close #61 