### PR TITLE
[feat] #66 상점 편지지 구매 api 구현

### DIFF
--- a/src/main/java/com/fling/fllingbe/domain/item/domain/CardItem.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/domain/CardItem.java
@@ -1,13 +1,10 @@
 package com.fling.fllingbe.domain.item.domain;
 
-
 import com.fling.fllingbe.domain.user.domain.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+@Setter
 @Getter
 @Builder
 @NoArgsConstructor

--- a/src/main/java/com/fling/fllingbe/domain/item/exception/CardItemNotFoundException.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/exception/CardItemNotFoundException.java
@@ -1,0 +1,10 @@
+package com.fling.fllingbe.domain.item.exception;
+
+import com.fling.fllingbe.global.error.ErrorCode;
+import com.fling.fllingbe.global.error.exception.ServiceException;
+
+public class CardItemNotFoundException extends ServiceException {
+    public CardItemNotFoundException() {
+        super(ErrorCode.CARD_ITEM_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/item/exception/CardTypeNotFoundException.java
+++ b/src/main/java/com/fling/fllingbe/domain/item/exception/CardTypeNotFoundException.java
@@ -1,0 +1,10 @@
+package com.fling.fllingbe.domain.item.exception;
+
+import com.fling.fllingbe.global.error.ErrorCode;
+import com.fling.fllingbe.global.error.exception.ServiceException;
+
+public class CardTypeNotFoundException extends ServiceException {
+    public CardTypeNotFoundException() {
+        super(ErrorCode.CARD_TYPE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/store/application/StoreService.java
+++ b/src/main/java/com/fling/fllingbe/domain/store/application/StoreService.java
@@ -6,25 +6,14 @@ import com.fling.fllingbe.domain.coin.exception.InsufficientCoinBalanceException
 import com.fling.fllingbe.domain.coin.repository.CoinRepository;
 import com.fling.fllingbe.domain.flower.exception.FlowerItemNotFoundException;
 import com.fling.fllingbe.domain.flower.exception.FlowerTypeNotFoundException;
-import com.fling.fllingbe.domain.item.domain.DecoItem;
-import com.fling.fllingbe.domain.item.domain.DecoType;
-import com.fling.fllingbe.domain.item.domain.FlowerItem;
-import com.fling.fllingbe.domain.item.domain.FlowerType;
-import com.fling.fllingbe.domain.item.exception.DecoItemNotFoundException;
-import com.fling.fllingbe.domain.item.exception.DecoTypeNotFoundException;
-import com.fling.fllingbe.domain.item.repository.DecoItemRepository;
-import com.fling.fllingbe.domain.item.repository.DecoTypeRepository;
-import com.fling.fllingbe.domain.item.repository.FlowerItemRepository;
-import com.fling.fllingbe.domain.item.repository.FlowerTypeRepository;
-import com.fling.fllingbe.domain.store.dto.DecoPurchaseRequest;
-import com.fling.fllingbe.domain.item.domain.CardItem;
-import com.fling.fllingbe.domain.item.domain.CardType;
-import com.fling.fllingbe.domain.item.domain.FlowerItem;
-import com.fling.fllingbe.domain.item.domain.FlowerType;
+import com.fling.fllingbe.domain.item.domain.*;
 import com.fling.fllingbe.domain.item.exception.CardItemNotFoundException;
 import com.fling.fllingbe.domain.item.exception.CardTypeNotFoundException;
+import com.fling.fllingbe.domain.item.exception.DecoItemNotFoundException;
+import com.fling.fllingbe.domain.item.exception.DecoTypeNotFoundException;
 import com.fling.fllingbe.domain.item.repository.*;
 import com.fling.fllingbe.domain.store.dto.CardPurchaseRequest;
+import com.fling.fllingbe.domain.store.dto.DecoPurchaseRequest;
 import com.fling.fllingbe.domain.store.dto.FlowerPurchaseRequest;
 import com.fling.fllingbe.domain.user.domain.User;
 import com.fling.fllingbe.domain.user.exception.UserNotFoundException;
@@ -85,7 +74,7 @@ public class StoreService {
         decoItem.setOwned(true);
         decoItemRepository.save(decoItem);
     }
-    
+
     public void purchaseCard(CardPurchaseRequest request, String userEmail) {
         User user = userRepository.findByEmail(userEmail).orElseThrow(UserNotFoundException::new);
         CardType cardType = cardTypeRepository.findById(request.getCardId())

--- a/src/main/java/com/fling/fllingbe/domain/store/dto/CardPurchaseRequest.java
+++ b/src/main/java/com/fling/fllingbe/domain/store/dto/CardPurchaseRequest.java
@@ -1,0 +1,11 @@
+package com.fling.fllingbe.domain.store.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CardPurchaseRequest {
+    private Long cardId;
+    private Integer count;
+}

--- a/src/main/java/com/fling/fllingbe/domain/store/presentation/StoreController.java
+++ b/src/main/java/com/fling/fllingbe/domain/store/presentation/StoreController.java
@@ -3,6 +3,7 @@ package com.fling.fllingbe.domain.store.presentation;
 import com.fling.fllingbe.domain.item.application.DecoItemService;
 import com.fling.fllingbe.domain.store.application.StoreService;
 import com.fling.fllingbe.domain.store.dto.DecoPurchaseRequest;
+import com.fling.fllingbe.domain.store.dto.CardPurchaseRequest;
 import com.fling.fllingbe.domain.store.dto.FlowerPurchaseRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -32,5 +33,11 @@ public class StoreController {
     public ResponseEntity<Map<String, String>> purchaseDeco(Authentication authentication, @RequestBody DecoPurchaseRequest request) {
         storeService.purchaseDeco(request, authentication.getName());
         return new ResponseEntity<>(Map.of("message", "데코 구매를 성공했습니다."), HttpStatus.OK);
+    }
+
+    @PostMapping("/card")
+    public ResponseEntity<Map<String, String>> purchaseCard(Authentication authentication, @RequestBody CardPurchaseRequest request) {
+        storeService.purchaseCard(request, authentication.getName());
+        return new ResponseEntity<>(Map.of("message", "편지지 구매를 성공했습니다."), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/store/presentation/StoreController.java
+++ b/src/main/java/com/fling/fllingbe/domain/store/presentation/StoreController.java
@@ -2,8 +2,8 @@ package com.fling.fllingbe.domain.store.presentation;
 
 import com.fling.fllingbe.domain.item.application.DecoItemService;
 import com.fling.fllingbe.domain.store.application.StoreService;
-import com.fling.fllingbe.domain.store.dto.DecoPurchaseRequest;
 import com.fling.fllingbe.domain.store.dto.CardPurchaseRequest;
+import com.fling.fllingbe.domain.store.dto.DecoPurchaseRequest;
 import com.fling.fllingbe.domain.store.dto.FlowerPurchaseRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/fling/fllingbe/global/error/ErrorCode.java
+++ b/src/main/java/com/fling/fllingbe/global/error/ErrorCode.java
@@ -15,7 +15,9 @@ public enum ErrorCode {
     FLOWER_TYPE_NOT_FOUND(404, "FLOWER_TYPE_NOT_FOUND", "꽃 종류를 찾을 수 없습니다."),
     INSUFFICIENT_COIN_BALANCE(400, "INSUFFICIENT_COIN_BALANCE", "코인 잔액이 부족합니다."),
     DECO_TYPE_NOT_FOUND(404, "DECO_TYPE_NOT_FOUND", "데코 타입을 찾을 수 없습니다."),
-    DECO_ITEM_NOT_FOUND(404, "DECO_ITEM_NOT_FOUND", "데코 아이템을 찾을 수 없습니다.");
+    DECO_ITEM_NOT_FOUND(404, "DECO_ITEM_NOT_FOUND", "데코 아이템을 찾을 수 없습니다."),
+    CARD_TYPE_NOT_FOUND(404, "CARD_TYPE_NOT_FOUND", "카드 타입을 찾을 수 없습니다."),
+    CARD_ITEM_NOT_FOUND(404, "CARD_ITEM_NOT_FOUND", "카드 아이템을 찾을 수 없습니다.");
 
     private final int httpStatus;
     private final String code;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 상점 편지지 구매 API 구현합니다.
- POST /store/card으로 값을 요청합니다. 
- 편지를 구매하면 해당 owned값을 true로 변경합니다.
- 편지에 해당하는 코인 값을 user의 coin에서 차감합니다. 
- 요청값과 응답값은 다음과 같습니다. 

Request
```json
{
  "method": "POST",
  "path": "/store/card",
  "headers": {
    "Authorization": "Bearer {token}"
  },
  "body": {
    "cardId": "Long"
    "count": "Integer"
  }
}
```

성공적인 응답(Response)
```json
{
  "status": 200,
  "statusText": "OK",
  "headers": {
    "Content-Type": "application/json"
  },
  "body": {
    "message": "편지지 구매를 성공했습니다."
  }
}
```

에러 응답(Response)
```json
{
  "status": 400,
  "statusText": "BAD_REQUEST",
  "body": {
    "message": "편지지 구매를 실패했습니다."
  }
}
```
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="1061" alt="img1" src="https://github.com/Leets-Official/Fling-BE/assets/70849467/626adae2-9861-4ffd-9701-2bb23f2bd98a">
<img width="1061" alt="img2" src="https://github.com/Leets-Official/Fling-BE/assets/70849467/5f5b7d71-c1a5-4f3c-8e13-166c5e26e618">
<img width="1061" alt="img3" src="https://github.com/Leets-Official/Fling-BE/assets/70849467/01b7417e-b3d5-430a-a44b-16408dfe523a">

<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
close #64 