### PR TITLE
[feat] #81 사용자가 하루에 한 번만 코인을 뽑을 수 있도록 구현

### DIFF
--- a/src/main/java/com/fling/fllingbe/domain/coin/application/CoinResetScheduler.java
+++ b/src/main/java/com/fling/fllingbe/domain/coin/application/CoinResetScheduler.java
@@ -1,0 +1,27 @@
+package com.fling.fllingbe.domain.coin.application;
+
+import com.fling.fllingbe.domain.coin.domain.Coin;
+import com.fling.fllingbe.domain.coin.repository.CoinRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CoinResetScheduler {
+
+    private final CoinRepository coinRepository;
+
+    public CoinResetScheduler(CoinRepository coinRepository) {
+        this.coinRepository = coinRepository;
+    }
+
+    @Scheduled(cron = "00 17 01 * * ?")
+    public void resetHasPickCoinToday() {
+        List<Coin> coins = coinRepository.findAll();
+        for (Coin coin : coins) {
+            coin.setHasPickCoinToday(false);
+            coinRepository.save(coin);
+        }
+    }
+}

--- a/src/main/java/com/fling/fllingbe/domain/coin/application/CoinResetScheduler.java
+++ b/src/main/java/com/fling/fllingbe/domain/coin/application/CoinResetScheduler.java
@@ -16,7 +16,7 @@ public class CoinResetScheduler {
         this.coinRepository = coinRepository;
     }
 
-    @Scheduled(cron = "00 17 01 * * ?")
+    @Scheduled(cron = "00 00 00 * * ?")
     public void resetHasPickCoinToday() {
         List<Coin> coins = coinRepository.findAll();
         for (Coin coin : coins) {

--- a/src/main/java/com/fling/fllingbe/domain/coin/application/CoinService.java
+++ b/src/main/java/com/fling/fllingbe/domain/coin/application/CoinService.java
@@ -8,6 +8,7 @@ import com.fling.fllingbe.domain.user.exception.UserNotFoundException;
 import com.fling.fllingbe.domain.user.repository.UserRepository;
 import com.fling.fllingbe.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,7 +24,13 @@ public class CoinService {
     public void updateCoin(String userEmail, Integer newCoinValue) {
         User user = userRepository.findByEmail(userEmail).orElseThrow(() -> new UserNotFoundException());
         Coin coin = coinRepository.findByUser(user).orElseThrow(CoinNotFoundException::new);
+
+        if (coin.getHasPickCoinToday()) {
+            throw new IllegalStateException("이미 오늘의 코인을 뽑으셨습니다.");
+        }
+//
         coin.setCoin(newCoinValue + coin.getCoin());
+        coin.setHasPickCoinToday(true);
         coinRepository.save(coin);
     }
 }

--- a/src/main/java/com/fling/fllingbe/domain/coin/domain/Coin.java
+++ b/src/main/java/com/fling/fllingbe/domain/coin/domain/Coin.java
@@ -1,6 +1,5 @@
 package com.fling.fllingbe.domain.coin.domain;
 
-import com.fasterxml.jackson.databind.ser.Serializers;
 import com.fling.fllingbe.domain.user.domain.User;
 import com.fling.fllingbe.global.shared.domain.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -24,4 +23,9 @@ public class Coin extends BaseTimeEntity {
 
     @Column
     private Integer coin;
+
+    @Builder.Default
+    @Column
+    private Boolean hasPickCoinToday = false;
+
 }

--- a/src/main/java/com/fling/fllingbe/domain/user/application/UserService.java
+++ b/src/main/java/com/fling/fllingbe/domain/user/application/UserService.java
@@ -73,6 +73,7 @@ public class UserService {
         Coin coin = Coin.builder()
                 .user(user)
                 .coin(1000)
+                .hasPickCoinToday(false)
                 .build();
         userRepository.save(user);
         coinRepository.save(coin);
@@ -172,6 +173,7 @@ public class UserService {
         Coin coin = Coin.builder()
                 .user(user)
                 .coin(1000)
+                .hasPickCoinToday(false)
                 .build();
         userRepository.save(user);
         coinRepository.save(coin);


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- Coin 엔티티에 hasPickCoinToday 필드를 추가하였습니다.
- /coin 엔드포인트에서 코인을 뽑을 때 hasPickCoinToday를 true로 설정하도록 변경하였습니다.
- 매일 자정에 모든 사용자의 hasPickCoinToday 필드를 false로 초기화하는 스케줄러를 추가하였습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="1181" alt="img" src="https://github.com/Leets-Official/Fling-BE/assets/70849467/20a19d03-7b15-4b27-8b5c-9d144681a9d8">
<img width="1516" alt="img" src="https://github.com/Leets-Official/Fling-BE/assets/70849467/35afdaf6-84c2-4ff6-bfe7-6c400f411dc2">

<br>

## 4. 완료 사항
- /coin 엔드포인트 요청 후 hasPickCoinToday 값이 true로 설정되는지 확인
- 자정 스케줄러 실행 후 모든 사용자의 hasPickCoinToday 값이 false로 리셋되는지 확인
<br>

## 5. 추가 사항
close #80 