### PR TITLE
[feat] #83 운영서버에서 swagger UI page 접근 비활성화

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,8 +14,8 @@ jwt.refresh_secret=${JWT_REFRESH_SECRET}
 cors.origin.development=${CORS_DEVELOPMENT}
 cors.origin.production=${CORS_PRODUCTION}
 
-spring.jwt.token.access-expiration-time=43200000
-spring.jwt.token.refresh-expiration-time=604800000
+spring.jwt.token.access-expiration-time=${ACCESS_TOKEN_EXPIRATION_TIME}
+spring.jwt.token.refresh-expiration-time=${REFRESH_TOKEN_EXPIRATION_TIME}
 
 spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}
@@ -27,3 +27,4 @@ server.compression.enabled=true
 server.compression.mime-types=text/html,text/plain,text/css,application/javascript,application/json
 server.compression.min-response-size=500
 
+springdoc.swagger-ui.enabled=false


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 명세서의 모든 api가 개발이 완료되어서 swagger 페이지를 운영서버에서 노출시킬 필요가 없다고 판단했습니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- API 명세서가 노출되면 인증이 필요 없는 엔드포인트를 악용할 수 있습니다.
- 또한 접근할 수 있는 데이터(ex. 개인정보)가 노출될 위험이 있습니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="875" alt="image" src="https://github.com/Leets-Official/Fling-BE/assets/125895298/8b8420ff-d837-45c8-a437-9e24acf43b6d">

- 로컬에서 확인 완료
<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
close #82 